### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
+permissions:
+  contents: read
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/vailabel/vailabel-studio/security/code-scanning/3](https://github.com/vailabel/vailabel-studio/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the workflow level to restrict the permissions of the `GITHUB_TOKEN`. Based on the workflow's steps, it primarily involves checking out the repository and building the project, which only requires `contents: read`. No write permissions are necessary for this workflow.

The `permissions` block will be added at the root level of the workflow, ensuring that all jobs inherit these minimal permissions unless explicitly overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
