### PR TITLE
Potential fix for code scanning alert no. 7: Information exposure through an exception

### DIFF
--- a/apps/api/exception_handlers.py
+++ b/apps/api/exception_handlers.py
@@ -36,13 +36,14 @@ def register_exception_handlers(app):
     # Handle all other unhandled exceptions
     @app.exception_handler(Exception)
     async def unhandled_exception_handler(request: Request, exc: Exception):
+        import logging
+        logging.error("Unhandled exception occurred: %s", traceback.format_exc())
         return JSONResponse(
             status_code=500,
             content={
                 "error": {
                     "type": "InternalServerError",
-                    "message": str(exc),
-                    "details": traceback.format_exc()
+                    "message": "An unexpected error has occurred. Please try again later."
                 }
             },
         )


### PR DESCRIPTION
Potential fix for [https://github.com/vailabel/vailabel-studio/security/code-scanning/7](https://github.com/vailabel/vailabel-studio/security/code-scanning/7)

To fix the issue, the stack trace (`traceback.format_exc()`) should no longer be included in the JSON response sent to the user. Instead, it should be logged on the server for debugging purposes, while providing a generic error message to the user. This ensures that developers retain access to detailed debugging information without exposing sensitive data to external users.

The following steps are required:
1. Remove `traceback.format_exc()` from the user-facing JSON response in the `unhandled_exception_handler`.
2. Log the stack trace using a logging library (e.g., Python's built-in `logging` module).
3. Return a generic error message to the user instead.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
