### PR TITLE
refactor(web): flat redesign, accurate feature content, Base UI nav

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -97,3 +97,95 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* ── Cloud design system ──────────────────────────────────────────────── */
+@layer components {
+  /* Gradient brand text */
+  .text-gradient {
+    background-image: linear-gradient(to right, #2563eb, #4f46e5, #7c3aed);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+
+  /* Frosted-glass surface used by cards, panels and the header */
+  .glass {
+    background-color: rgb(255 255 255 / 0.7);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid rgb(15 23 42 / 0.06);
+  }
+  .dark .glass {
+    background-color: rgb(255 255 255 / 0.04);
+    border-color: rgb(255 255 255 / 0.08);
+  }
+
+  /* Card hover lift */
+  .cloud-card {
+    transition:
+      transform 0.25s ease,
+      box-shadow 0.25s ease,
+      border-color 0.25s ease;
+  }
+  .cloud-card:hover {
+    transform: translateY(-4px);
+  }
+}
+
+/* Soft aurora glow used behind the hero / CTA */
+.cloud-aurora {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 0;
+}
+.cloud-aurora::before,
+.cloud-aurora::after {
+  content: "";
+  position: absolute;
+  border-radius: 9999px;
+  filter: blur(80px);
+  opacity: 0.5;
+}
+.cloud-aurora::before {
+  width: 480px;
+  height: 480px;
+  top: -160px;
+  left: -120px;
+  background: radial-gradient(circle, rgba(59, 130, 246, 0.5), transparent 70%);
+}
+.cloud-aurora::after {
+  width: 520px;
+  height: 520px;
+  top: -120px;
+  right: -160px;
+  background: radial-gradient(circle, rgba(124, 58, 237, 0.45), transparent 70%);
+}
+.dark .cloud-aurora::before,
+.dark .cloud-aurora::after {
+  opacity: 0.35;
+}
+
+/* Subtle dotted grid backdrop */
+.cloud-grid {
+  background-image: radial-gradient(
+    rgb(99 102 241 / 0.12) 1px,
+    transparent 1px
+  );
+  background-size: 22px 22px;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+.animate-fade-in {
+  animation: fade-in 0.2s ease-out both;
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -98,82 +98,36 @@
   }
 }
 
-/* ── Cloud design system ──────────────────────────────────────────────── */
+/* ── Design system ────────────────────────────────────────────────────── */
 @layer components {
-  /* Gradient brand text */
-  .text-gradient {
-    background-image: linear-gradient(to right, #2563eb, #4f46e5, #7c3aed);
-    -webkit-background-clip: text;
-    background-clip: text;
-    color: transparent;
+  /* Solid brand accent for emphasised words */
+  .brand-accent {
+    color: #2563eb;
+  }
+  .dark .brand-accent {
+    color: #60a5fa;
   }
 
-  /* Frosted-glass surface used by cards, panels and the header */
-  .glass {
-    background-color: rgb(255 255 255 / 0.7);
-    backdrop-filter: blur(16px);
-    -webkit-backdrop-filter: blur(16px);
-    border: 1px solid rgb(15 23 42 / 0.06);
+  /* Clean card surface used by feature/roadmap cards and the header */
+  .surface {
+    background-color: #ffffff;
+    border: 1px solid rgb(15 23 42 / 0.08);
   }
-  .dark .glass {
-    background-color: rgb(255 255 255 / 0.04);
+  .dark .surface {
+    background-color: rgb(17 24 39 / 1);
     border-color: rgb(255 255 255 / 0.08);
   }
 
   /* Card hover lift */
   .cloud-card {
     transition:
-      transform 0.25s ease,
-      box-shadow 0.25s ease,
-      border-color 0.25s ease;
+      transform 0.2s ease,
+      box-shadow 0.2s ease,
+      border-color 0.2s ease;
   }
   .cloud-card:hover {
-    transform: translateY(-4px);
+    transform: translateY(-3px);
   }
-}
-
-/* Soft aurora glow used behind the hero / CTA */
-.cloud-aurora {
-  position: absolute;
-  inset: 0;
-  overflow: hidden;
-  pointer-events: none;
-  z-index: 0;
-}
-.cloud-aurora::before,
-.cloud-aurora::after {
-  content: "";
-  position: absolute;
-  border-radius: 9999px;
-  filter: blur(80px);
-  opacity: 0.5;
-}
-.cloud-aurora::before {
-  width: 480px;
-  height: 480px;
-  top: -160px;
-  left: -120px;
-  background: radial-gradient(circle, rgba(59, 130, 246, 0.5), transparent 70%);
-}
-.cloud-aurora::after {
-  width: 520px;
-  height: 520px;
-  top: -120px;
-  right: -160px;
-  background: radial-gradient(circle, rgba(124, 58, 237, 0.45), transparent 70%);
-}
-.dark .cloud-aurora::before,
-.dark .cloud-aurora::after {
-  opacity: 0.35;
-}
-
-/* Subtle dotted grid backdrop */
-.cloud-grid {
-  background-image: radial-gradient(
-    rgb(99 102 241 / 0.12) 1px,
-    transparent 1px
-  );
-  background-size: 22px 22px;
 }
 
 @keyframes fade-in {

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -35,7 +35,7 @@ export const metadata = {
 
 export default function Home() {
   return (
-    <div className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-slate-50 dark:from-gray-950 dark:via-gray-900 dark:to-gray-950 text-gray-900 dark:text-gray-100">
+    <div className="min-h-screen bg-slate-50 dark:bg-gray-950 text-gray-900 dark:text-gray-100">
       <main>
         <HeroSection />
         <FeatureHighlights />

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -35,7 +35,7 @@ export const metadata = {
 
 export default function Home() {
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 transition-colors duration-200">
+    <div className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-slate-50 dark:from-gray-950 dark:via-gray-900 dark:to-gray-950 text-gray-900 dark:text-gray-100">
       <main>
         <HeroSection />
         <FeatureHighlights />

--- a/apps/web/components/cta-section.tsx
+++ b/apps/web/components/cta-section.tsx
@@ -7,40 +7,43 @@ import React from "react"
 
 const CTASection = () => {
   return (
-    <section className="py-16 bg-gradient-to-r from-blue-600 to-indigo-700 text-white">
+    <section className="py-20">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <motion.div
-          className="text-center max-w-3xl mx-auto"
-          initial={{ opacity: 0, scale: 0.9 }}
+          className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-blue-600 via-indigo-600 to-violet-700 text-white px-6 py-16 md:py-20 text-center shadow-2xl shadow-indigo-500/30"
+          initial={{ opacity: 0, scale: 0.96 }}
           whileInView={{ opacity: 1, scale: 1 }}
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
-          <h2 className="text-3xl md:text-4xl font-bold mb-6">
-            Ready to transform your image labeling workflow?
-          </h2>
-          <p className="text-xl mb-8 text-blue-100">
-            Start using Vision AI Label Studio today and experience the power of
-            AI-assisted annotation.
-          </p>
-          <div className="flex flex-col sm:flex-row justify-center gap-4">
-            <motion.a
-              href="#download"
-              className="px-8 py-3 rounded-lg bg-white text-blue-600 font-medium hover:bg-blue-50 transition-colors flex items-center justify-center gap-2"
-              whileHover={{ scale: 1.05 }}
-              whileTap={{ scale: 0.95 }}
-            >
-              Download Now <ArrowRight size={18} />
-            </motion.a>
-            <motion.a
-              href="https://github.com/vailabel/vailabel-studio"
-              target="_blank"
-              className="px-8 py-3 rounded-lg bg-blue-700 text-white font-medium hover:bg-blue-800 transition-colors flex items-center justify-center gap-2 border border-white"
-              whileHover={{ scale: 1.05 }}
-              whileTap={{ scale: 0.95 }}
-            >
-              <GithubIcon size={18} /> Star on GitHub
-            </motion.a>
+          <div className="cloud-aurora opacity-40" aria-hidden="true" />
+          <div className="relative z-10 max-w-3xl mx-auto">
+            <h2 className="text-3xl md:text-4xl font-bold mb-6">
+              Ready to transform your image labeling workflow?
+            </h2>
+            <p className="text-xl mb-8 text-blue-100">
+              Start using Vision AI Label Studio today and experience the power
+              of AI-assisted annotation.
+            </p>
+            <div className="flex flex-col sm:flex-row justify-center gap-4">
+              <motion.a
+                href="#download"
+                className="px-8 py-3.5 rounded-xl bg-white text-blue-700 font-semibold shadow-lg hover:shadow-xl transition-shadow flex items-center justify-center gap-2"
+                whileHover={{ scale: 1.04 }}
+                whileTap={{ scale: 0.96 }}
+              >
+                Download Now <ArrowRight size={18} />
+              </motion.a>
+              <motion.a
+                href="https://github.com/vailabel/vailabel-studio"
+                target="_blank"
+                className="px-8 py-3.5 rounded-xl bg-white/10 text-white font-semibold ring-1 ring-white/30 backdrop-blur-sm hover:bg-white/20 transition-colors flex items-center justify-center gap-2"
+                whileHover={{ scale: 1.04 }}
+                whileTap={{ scale: 0.96 }}
+              >
+                <GithubIcon size={18} /> Star on GitHub
+              </motion.a>
+            </div>
           </div>
         </motion.div>
       </div>

--- a/apps/web/components/cta-section.tsx
+++ b/apps/web/components/cta-section.tsx
@@ -10,25 +10,24 @@ const CTASection = () => {
     <section className="py-20">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <motion.div
-          className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-blue-600 via-indigo-600 to-violet-700 text-white px-6 py-16 md:py-20 text-center shadow-2xl shadow-indigo-500/30"
+          className="rounded-3xl bg-blue-600 text-white px-6 py-16 md:py-20 text-center"
           initial={{ opacity: 0, scale: 0.96 }}
           whileInView={{ opacity: 1, scale: 1 }}
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
-          <div className="cloud-aurora opacity-40" aria-hidden="true" />
-          <div className="relative z-10 max-w-3xl mx-auto">
+          <div className="max-w-3xl mx-auto">
             <h2 className="text-3xl md:text-4xl font-bold mb-6">
               Ready to transform your image labeling workflow?
             </h2>
             <p className="text-xl mb-8 text-blue-100">
-              Start using Vision AI Label Studio today and experience the power
-              of AI-assisted annotation.
+              Download Vision AI Label Studio today and experience the power of
+              AI-assisted annotation.
             </p>
             <div className="flex flex-col sm:flex-row justify-center gap-4">
               <motion.a
                 href="#download"
-                className="px-8 py-3.5 rounded-xl bg-white text-blue-700 font-semibold shadow-lg hover:shadow-xl transition-shadow flex items-center justify-center gap-2"
+                className="px-8 py-3.5 rounded-xl bg-white text-blue-700 font-semibold hover:bg-blue-50 transition-colors flex items-center justify-center gap-2"
                 whileHover={{ scale: 1.04 }}
                 whileTap={{ scale: 0.96 }}
               >
@@ -37,7 +36,7 @@ const CTASection = () => {
               <motion.a
                 href="https://github.com/vailabel/vailabel-studio"
                 target="_blank"
-                className="px-8 py-3.5 rounded-xl bg-white/10 text-white font-semibold ring-1 ring-white/30 backdrop-blur-sm hover:bg-white/20 transition-colors flex items-center justify-center gap-2"
+                className="px-8 py-3.5 rounded-xl bg-blue-700 text-white font-semibold ring-1 ring-white/30 hover:bg-blue-800 transition-colors flex items-center justify-center gap-2"
                 whileHover={{ scale: 1.04 }}
                 whileTap={{ scale: 0.96 }}
               >

--- a/apps/web/components/demo-section.tsx
+++ b/apps/web/components/demo-section.tsx
@@ -5,7 +5,7 @@ import React from "react"
 
 const DemoSection = () => {
   return (
-    <section className="py-16 bg-gradient-to-b from-gray-100 to-white dark:from-gray-800 dark:to-gray-900">
+    <section className="relative py-20">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <motion.div
           className="text-center mb-12"
@@ -14,8 +14,8 @@ const DemoSection = () => {
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
-          <h2 className="text-3xl md:text-4xl font-bold mb-4">
-            See It In Action
+          <h2 className="text-3xl md:text-5xl font-bold tracking-tight mb-4">
+            See It In <span className="text-gradient">Action</span>
           </h2>
           <p className="text-xl text-gray-600 dark:text-gray-400 max-w-3xl mx-auto">
             Watch how Vision AI Label Studio makes image annotation fast and
@@ -24,7 +24,7 @@ const DemoSection = () => {
         </motion.div>
 
         <motion.div
-          className="max-w-4xl mx-auto rounded-xl overflow-hidden shadow-2xl border border-gray-200 dark:border-gray-700"
+          className="max-w-4xl mx-auto rounded-2xl overflow-hidden shadow-2xl shadow-blue-500/10 ring-1 ring-black/5 dark:ring-white/10"
           initial={{ opacity: 0, y: 40 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
@@ -39,7 +39,7 @@ const DemoSection = () => {
               allowFullScreen
             />
           </div>
-          <div className="bg-white dark:bg-gray-800 p-4 flex justify-between items-center">
+          <div className="glass p-4 flex justify-between items-center">
             <div className="text-sm text-gray-600 dark:text-gray-400">
               Demo: AI-assisted annotation workflow
             </div>

--- a/apps/web/components/demo-section.tsx
+++ b/apps/web/components/demo-section.tsx
@@ -15,7 +15,7 @@ const DemoSection = () => {
           transition={{ duration: 0.5 }}
         >
           <h2 className="text-3xl md:text-5xl font-bold tracking-tight mb-4">
-            See It In <span className="text-gradient">Action</span>
+            See It In <span className="brand-accent">Action</span>
           </h2>
           <p className="text-xl text-gray-600 dark:text-gray-400 max-w-3xl mx-auto">
             Watch how Vision AI Label Studio makes image annotation fast and
@@ -39,7 +39,7 @@ const DemoSection = () => {
               allowFullScreen
             />
           </div>
-          <div className="glass p-4 flex justify-between items-center">
+          <div className="surface p-4 flex justify-between items-center">
             <div className="text-sm text-gray-600 dark:text-gray-400">
               Demo: AI-assisted annotation workflow
             </div>

--- a/apps/web/components/download-button.tsx
+++ b/apps/web/components/download-button.tsx
@@ -78,7 +78,7 @@ const DownloadButton: React.FC = () => {
     >
       <a
         href={releaseAssets[platform] || undefined}
-        className={`flex-1 flex items-center justify-center px-4 py-3 sm:px-6 rounded-lg sm:rounded-l-lg sm:rounded-r-none bg-blue-600 text-white font-semibold shadow-lg hover:bg-blue-700 transition-all duration-200 gap-2 sm:gap-3 text-base sm:text-lg min-w-0 ${
+        className={`flex-1 flex items-center justify-center px-4 py-3 sm:px-6 rounded-lg sm:rounded-l-lg sm:rounded-r-none bg-gradient-to-r from-blue-600 to-indigo-600 text-white font-semibold shadow-lg shadow-blue-500/25 hover:shadow-xl hover:shadow-blue-500/30 transition-shadow duration-200 gap-2 sm:gap-3 text-base sm:text-lg min-w-0 ${
           !releaseAssets[platform] ? "opacity-50 pointer-events-none" : ""
         }`}
         style={{

--- a/apps/web/components/download-button.tsx
+++ b/apps/web/components/download-button.tsx
@@ -78,7 +78,7 @@ const DownloadButton: React.FC = () => {
     >
       <a
         href={releaseAssets[platform] || undefined}
-        className={`flex-1 flex items-center justify-center px-4 py-3 sm:px-6 rounded-lg sm:rounded-l-lg sm:rounded-r-none bg-gradient-to-r from-blue-600 to-indigo-600 text-white font-semibold shadow-lg shadow-blue-500/25 hover:shadow-xl hover:shadow-blue-500/30 transition-shadow duration-200 gap-2 sm:gap-3 text-base sm:text-lg min-w-0 ${
+        className={`flex-1 flex items-center justify-center px-4 py-3 sm:px-6 rounded-lg sm:rounded-l-lg sm:rounded-r-none bg-blue-600 hover:bg-blue-700 text-white font-semibold shadow-sm transition-colors duration-200 gap-2 sm:gap-3 text-base sm:text-lg min-w-0 ${
           !releaseAssets[platform] ? "opacity-50 pointer-events-none" : ""
         }`}
         style={{

--- a/apps/web/components/feature-highlights.tsx
+++ b/apps/web/components/feature-highlights.tsx
@@ -6,7 +6,7 @@ import React from "react"
 
 const FeatureHighlights = () => {
   return (
-    <section className="py-16 bg-gray-100 dark:bg-gray-800/50">
+    <section className="relative py-20">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <motion.div
           className="text-center mb-16"
@@ -15,8 +15,8 @@ const FeatureHighlights = () => {
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
-          <h2 className="text-3xl md:text-4xl font-bold mb-4">
-            Powerful Features
+          <h2 className="text-3xl md:text-5xl font-bold tracking-tight mb-4">
+            Powerful <span className="text-gradient">Features</span>
           </h2>
           <p className="text-xl text-gray-600 dark:text-gray-400 max-w-3xl mx-auto">
             Everything you need for efficient image annotation and labeling
@@ -32,10 +32,10 @@ const FeatureHighlights = () => {
         >
           {/* Feature 1 */}
           <motion.div
-            className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-200 dark:border-gray-700"
+            className="glass cloud-card rounded-2xl p-6 shadow-lg shadow-slate-200/40 dark:shadow-none hover:shadow-xl hover:shadow-blue-500/10"
             variants={item}
           >
-            <div className="w-12 h-12 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center text-blue-600 dark:text-blue-400 mb-4">
+            <div className="w-12 h-12 rounded-xl flex items-center justify-center text-white shadow-lg shadow-blue-500/30 mb-4 bg-gradient-to-br from-blue-500 to-indigo-600">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
@@ -60,10 +60,10 @@ const FeatureHighlights = () => {
 
           {/* Feature 2 */}
           <motion.div
-            className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-200 dark:border-gray-700"
+            className="glass cloud-card rounded-2xl p-6 shadow-lg shadow-slate-200/40 dark:shadow-none hover:shadow-xl hover:shadow-blue-500/10"
             variants={item}
           >
-            <div className="w-12 h-12 bg-indigo-100 dark:bg-indigo-900/30 rounded-lg flex items-center justify-center text-indigo-600 dark:text-indigo-400 mb-4">
+            <div className="w-12 h-12 rounded-xl flex items-center justify-center text-white shadow-lg shadow-indigo-500/30 mb-4 bg-gradient-to-br from-indigo-500 to-violet-600">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
@@ -89,10 +89,10 @@ const FeatureHighlights = () => {
 
           {/* Feature 3 */}
           <motion.div
-            className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-200 dark:border-gray-700"
+            className="glass cloud-card rounded-2xl p-6 shadow-lg shadow-slate-200/40 dark:shadow-none hover:shadow-xl hover:shadow-blue-500/10"
             variants={item}
           >
-            <div className="w-12 h-12 bg-green-100 dark:bg-green-900/30 rounded-lg flex items-center justify-center text-green-600 dark:text-green-400 mb-4">
+            <div className="w-12 h-12 rounded-xl flex items-center justify-center text-white shadow-lg shadow-emerald-500/30 mb-4 bg-gradient-to-br from-emerald-500 to-teal-600">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
@@ -116,10 +116,10 @@ const FeatureHighlights = () => {
 
           {/* Feature 4 */}
           <motion.div
-            className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-200 dark:border-gray-700"
+            className="glass cloud-card rounded-2xl p-6 shadow-lg shadow-slate-200/40 dark:shadow-none hover:shadow-xl hover:shadow-blue-500/10"
             variants={item}
           >
-            <div className="w-12 h-12 bg-purple-100 dark:bg-purple-900/30 rounded-lg flex items-center justify-center text-purple-600 dark:text-purple-400 mb-4">
+            <div className="w-12 h-12 rounded-xl flex items-center justify-center text-white shadow-lg shadow-purple-500/30 mb-4 bg-gradient-to-br from-purple-500 to-fuchsia-600">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
@@ -145,10 +145,10 @@ const FeatureHighlights = () => {
 
           {/* Feature 5 */}
           <motion.div
-            className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-200 dark:border-gray-700"
+            className="glass cloud-card rounded-2xl p-6 shadow-lg shadow-slate-200/40 dark:shadow-none hover:shadow-xl hover:shadow-blue-500/10"
             variants={item}
           >
-            <div className="w-12 h-12 bg-orange-100 dark:bg-orange-900/30 rounded-lg flex items-center justify-center text-orange-600 dark:text-orange-400 mb-4">
+            <div className="w-12 h-12 rounded-xl flex items-center justify-center text-white shadow-lg shadow-orange-500/30 mb-4 bg-gradient-to-br from-orange-500 to-amber-600">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
@@ -174,10 +174,10 @@ const FeatureHighlights = () => {
 
           {/* Feature 6 */}
           <motion.div
-            className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-200 dark:border-gray-700"
+            className="glass cloud-card rounded-2xl p-6 shadow-lg shadow-slate-200/40 dark:shadow-none hover:shadow-xl hover:shadow-blue-500/10"
             variants={item}
           >
-            <div className="w-12 h-12 bg-pink-100 dark:bg-pink-900/30 rounded-lg flex items-center justify-center text-pink-600 dark:text-pink-400 mb-4">
+            <div className="w-12 h-12 rounded-xl flex items-center justify-center text-white shadow-lg shadow-pink-500/30 mb-4 bg-gradient-to-br from-pink-500 to-rose-600">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"

--- a/apps/web/components/feature-highlights.tsx
+++ b/apps/web/components/feature-highlights.tsx
@@ -2,7 +2,65 @@
 
 import { container, item } from "@/lib/motion"
 import { motion } from "framer-motion"
-import React from "react"
+import {
+  Shapes,
+  Wand2,
+  FileDown,
+  Database,
+  Cloud,
+  Laptop,
+  type LucideIcon,
+} from "lucide-react"
+
+type Feature = {
+  icon: LucideIcon
+  title: string
+  description: string
+  tint: string
+}
+
+const features: Feature[] = [
+  {
+    icon: Shapes,
+    title: "Annotation Tools",
+    description:
+      "Draw boxes, polygons, points, lines, circles, and free-form masks with precise editing.",
+    tint: "bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400",
+  },
+  {
+    icon: Wand2,
+    title: "AI-Assisted Labeling",
+    description:
+      "Auto-detect objects with local ONNX models (YOLO-family) — GPU-accelerated and fully offline.",
+    tint: "bg-indigo-100 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400",
+  },
+  {
+    icon: FileDown,
+    title: "Multi-Format Export",
+    description: "Export annotations to LabelMe, COCO, YOLO, and Pascal VOC.",
+    tint: "bg-emerald-100 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400",
+  },
+  {
+    icon: Database,
+    title: "Local-First & Offline",
+    description:
+      "Projects are stored locally in SQLite — your data never leaves your machine.",
+    tint: "bg-purple-100 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400",
+  },
+  {
+    icon: Cloud,
+    title: "Cloud Storage",
+    description:
+      "Optionally connect your own S3, Azure, or GCS bucket for image storage.",
+    tint: "bg-orange-100 dark:bg-orange-900/30 text-orange-600 dark:text-orange-400",
+  },
+  {
+    icon: Laptop,
+    title: "Cross-Platform Desktop",
+    description: "Runs natively on Windows, macOS, and Linux — built with Tauri.",
+    tint: "bg-pink-100 dark:bg-pink-900/30 text-pink-600 dark:text-pink-400",
+  },
+]
 
 const FeatureHighlights = () => {
   return (
@@ -16,7 +74,7 @@ const FeatureHighlights = () => {
           transition={{ duration: 0.5 }}
         >
           <h2 className="text-3xl md:text-5xl font-bold tracking-tight mb-4">
-            Powerful <span className="text-gradient">Features</span>
+            Powerful <span className="brand-accent">Features</span>
           </h2>
           <p className="text-xl text-gray-600 dark:text-gray-400 max-w-3xl mx-auto">
             Everything you need for efficient image annotation and labeling
@@ -30,177 +88,23 @@ const FeatureHighlights = () => {
           whileInView="show"
           viewport={{ once: true }}
         >
-          {/* Feature 1 */}
-          <motion.div
-            className="glass cloud-card rounded-2xl p-6 shadow-lg shadow-slate-200/40 dark:shadow-none hover:shadow-xl hover:shadow-blue-500/10"
-            variants={item}
-          >
-            <div className="w-12 h-12 rounded-xl flex items-center justify-center text-white shadow-lg shadow-blue-500/30 mb-4 bg-gradient-to-br from-blue-500 to-indigo-600">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                strokeWidth={1.5}
-                stroke="currentColor"
-                className="w-6 h-6"
+          {features.map((feature) => (
+            <motion.div
+              key={feature.title}
+              className="surface cloud-card rounded-2xl p-6 shadow-sm hover:shadow-md"
+              variants={item}
+            >
+              <div
+                className={`w-12 h-12 rounded-xl flex items-center justify-center mb-4 ${feature.tint}`}
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M9.53 16.122a3 3 0 0 0-5.78 1.128 2.25 2.25 0 0 1-2.4 2.245 4.5 4.5 0 0 0 8.4-2.245c0-.399-.078-.78-.22-1.128Zm0 0a15.998 15.998 0 0 0 3.388-1.62m-5.043-.025a15.994 15.994 0 0 1 1.622-3.395m3.42 3.42a15.995 15.995 0 0 0 4.764-4.648l3.876-5.814a1.151 1.151 0 0 0-1.597-1.597L14.146 6.32a15.996 15.996 0 0 0-4.649 4.763m3.42 3.42a6.776 6.776 0 0 0-3.42-3.42"
-                />
-              </svg>
-            </div>
-            <h3 className="text-xl font-semibold mb-2">Manual Annotations</h3>
-            <p className="text-gray-600 dark:text-gray-400">
-              Create boxes, polygons, and free-form drawings with precision
-              tools.
-            </p>
-          </motion.div>
-
-          {/* Feature 2 */}
-          <motion.div
-            className="glass cloud-card rounded-2xl p-6 shadow-lg shadow-slate-200/40 dark:shadow-none hover:shadow-xl hover:shadow-blue-500/10"
-            variants={item}
-          >
-            <div className="w-12 h-12 rounded-xl flex items-center justify-center text-white shadow-lg shadow-indigo-500/30 mb-4 bg-gradient-to-br from-indigo-500 to-violet-600">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                strokeWidth={1.5}
-                stroke="currentColor"
-                className="w-6 h-6"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z"
-                />
-              </svg>
-            </div>
-            <h3 className="text-xl font-semibold mb-2">
-              AI Labeling with YOLOv8
-            </h3>
-            <p className="text-gray-600 dark:text-gray-400">
-              Accelerate your workflow with AI-assisted auto-labeling.
-            </p>
-          </motion.div>
-
-          {/* Feature 3 */}
-          <motion.div
-            className="glass cloud-card rounded-2xl p-6 shadow-lg shadow-slate-200/40 dark:shadow-none hover:shadow-xl hover:shadow-blue-500/10"
-            variants={item}
-          >
-            <div className="w-12 h-12 rounded-xl flex items-center justify-center text-white shadow-lg shadow-emerald-500/30 mb-4 bg-gradient-to-br from-emerald-500 to-teal-600">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                strokeWidth={1.5}
-                stroke="currentColor"
-                className="w-6 h-6"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5"
-                />
-              </svg>
-            </div>
-            <h3 className="text-xl font-semibold mb-2">Multi-Format Export</h3>
-            <p className="text-gray-600 dark:text-gray-400">
-              Export to COCO, YOLO, Pascal VOC, and JSON formats.
-            </p>
-          </motion.div>
-
-          {/* Feature 4 */}
-          <motion.div
-            className="glass cloud-card rounded-2xl p-6 shadow-lg shadow-slate-200/40 dark:shadow-none hover:shadow-xl hover:shadow-blue-500/10"
-            variants={item}
-          >
-            <div className="w-12 h-12 rounded-xl flex items-center justify-center text-white shadow-lg shadow-purple-500/30 mb-4 bg-gradient-to-br from-purple-500 to-fuchsia-600">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                strokeWidth={1.5}
-                stroke="currentColor"
-                className="w-6 h-6"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125"
-                />
-              </svg>
-            </div>
-            <h3 className="text-xl font-semibold mb-2">
-              Offline Project Storage
-            </h3>
-            <p className="text-gray-600 dark:text-gray-400">
-              Store projects locally with Dexie.js for complete offline support.
-            </p>
-          </motion.div>
-
-          {/* Feature 5 */}
-          <motion.div
-            className="glass cloud-card rounded-2xl p-6 shadow-lg shadow-slate-200/40 dark:shadow-none hover:shadow-xl hover:shadow-blue-500/10"
-            variants={item}
-          >
-            <div className="w-12 h-12 rounded-xl flex items-center justify-center text-white shadow-lg shadow-orange-500/30 mb-4 bg-gradient-to-br from-orange-500 to-amber-600">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                strokeWidth={1.5}
-                stroke="currentColor"
-                className="w-6 h-6"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M9 17.25v1.007a3 3 0 0 1-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0 1 15 18.257V17.25m6-12V15a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 15V5.25m18 0A2.25 2.25 0 0 0 18.75 3H5.25A2.25 2.25 0 0 0 3 5.25m18 0V12a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 12V5.25"
-                />
-              </svg>
-            </div>
-            <h3 className="text-xl font-semibold mb-2">
-              Cross-platform Desktop App
-            </h3>
-            <p className="text-gray-600 dark:text-gray-400">
-              Use on Windows, macOS, or Linux with the same great experience.
-            </p>
-          </motion.div>
-
-          {/* Feature 6 */}
-          <motion.div
-            className="glass cloud-card rounded-2xl p-6 shadow-lg shadow-slate-200/40 dark:shadow-none hover:shadow-xl hover:shadow-blue-500/10"
-            variants={item}
-          >
-            <div className="w-12 h-12 rounded-xl flex items-center justify-center text-white shadow-lg shadow-pink-500/30 mb-4 bg-gradient-to-br from-pink-500 to-rose-600">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                strokeWidth={1.5}
-                stroke="currentColor"
-                className="w-6 h-6"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M10.5 6h9.75M10.5 6a1.5 1.5 0 1 1-3 0m3 0a1.5 1.5 0 1 0-3 0M3.75 6H7.5m3 12h9.75m-9.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-3.75 0H7.5m9-6h3.75m-3.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-9.75 0h9.75"
-                />
-              </svg>
-            </div>
-            <h3 className="text-xl font-semibold mb-2">
-              Responsive Light/Dark UI
-            </h3>
-            <p className="text-gray-600 dark:text-gray-400">
-              Beautiful interface that adapts to your preferences and
-              environment.
-            </p>
-          </motion.div>
+                <feature.icon className="w-6 h-6" />
+              </div>
+              <h3 className="text-xl font-semibold mb-2">{feature.title}</h3>
+              <p className="text-gray-600 dark:text-gray-400">
+                {feature.description}
+              </p>
+            </motion.div>
+          ))}
         </motion.div>
       </div>
     </section>

--- a/apps/web/components/footer.tsx
+++ b/apps/web/components/footer.tsx
@@ -5,11 +5,13 @@ import Link from "next/link"
 
 export default function Footer() {
   return (
-    <footer className="bg-gray-100 dark:bg-gray-800 py-12 border-t border-gray-200 dark:border-gray-700">
+    <footer className="relative py-14 border-t border-black/5 dark:border-white/10 bg-white/50 dark:bg-white/[0.02] backdrop-blur-sm">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           <div>
-            <h3 className="font-bold text-lg mb-4">Vision AI Label Studio</h3>
+            <h3 className="font-bold text-lg mb-4 text-gradient">
+              Vision AI Label Studio
+            </h3>
             <p className="text-gray-600 dark:text-gray-400 mb-4">
               A powerful, open-source image labeling tool with AI assistance.
             </p>

--- a/apps/web/components/footer.tsx
+++ b/apps/web/components/footer.tsx
@@ -9,7 +9,7 @@ export default function Footer() {
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           <div>
-            <h3 className="font-bold text-lg mb-4 text-gradient">
+            <h3 className="font-bold text-lg mb-4 brand-accent">
               Vision AI Label Studio
             </h3>
             <p className="text-gray-600 dark:text-gray-400 mb-4">

--- a/apps/web/components/github-button.tsx
+++ b/apps/web/components/github-button.tsx
@@ -32,7 +32,7 @@ export default function GitHubButton({ repoUrl }: GitHubButtonProps) {
       href={repoUrl}
       target="_blank"
       rel="noopener noreferrer"
-      className="inline-flex items-center border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100 px-3 py-1.5 rounded-md font-semibold shadow-sm hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+      className="inline-flex items-center glass text-gray-800 dark:text-gray-100 px-3 py-1.5 rounded-lg font-semibold shadow-sm hover:shadow-md transition-shadow"
       style={{ minWidth: 110, justifyContent: "center" }}
     >
       <GithubIcon className="w-4 h-4 mr-2 text-gray-700 dark:text-gray-200" />

--- a/apps/web/components/github-button.tsx
+++ b/apps/web/components/github-button.tsx
@@ -32,7 +32,7 @@ export default function GitHubButton({ repoUrl }: GitHubButtonProps) {
       href={repoUrl}
       target="_blank"
       rel="noopener noreferrer"
-      className="inline-flex items-center glass text-gray-800 dark:text-gray-100 px-3 py-1.5 rounded-lg font-semibold shadow-sm hover:shadow-md transition-shadow"
+      className="inline-flex items-center surface text-gray-800 dark:text-gray-100 px-3 py-1.5 rounded-lg font-semibold shadow-sm hover:shadow-md transition-shadow"
       style={{ minWidth: 110, justifyContent: "center" }}
     >
       <GithubIcon className="w-4 h-4 mr-2 text-gray-700 dark:text-gray-200" />

--- a/apps/web/components/header.tsx
+++ b/apps/web/components/header.tsx
@@ -36,7 +36,7 @@ export default function Header() {
       : "text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white transition-colors"
 
   return (
-    <header className="sticky top-0 z-50 glass border-b border-black/5 dark:border-white/10">
+    <header className="sticky top-0 z-50 surface border-b border-black/5 dark:border-white/10">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center py-4">
           <Link href="/" className="flex items-center space-x-2">
@@ -47,7 +47,7 @@ export default function Header() {
               height={32}
               className="h-8 w-8"
             />
-            <span className="text-xl font-bold text-gradient">
+            <span className="text-xl font-bold brand-accent">
               Vision AI Label Studio
             </span>
           </Link>
@@ -63,7 +63,7 @@ export default function Header() {
             {mounted && (
               <button
                 onClick={toggleDarkMode}
-                className="p-2 rounded-full glass text-gray-700 dark:text-gray-300 hover:shadow-md transition-shadow"
+                className="p-2 rounded-full surface text-gray-700 dark:text-gray-300 hover:shadow-md transition-shadow"
                 aria-label="Toggle dark mode"
               >
                 {theme === "dark" ? <Sun size={18} /> : <Moon size={18} />}
@@ -87,7 +87,7 @@ export default function Header() {
                   sideOffset={8}
                   className="z-50"
                 >
-                  <Popover.Popup className="glass rounded-2xl shadow-xl p-4 w-56 flex flex-col gap-2 animate-fade-in">
+                  <Popover.Popup className="surface rounded-2xl shadow-xl p-4 w-56 flex flex-col gap-2 animate-fade-in">
                     {navLinks.map((link) => (
                       <Link
                         key={link.href}

--- a/apps/web/components/header.tsx
+++ b/apps/web/components/header.tsx
@@ -1,12 +1,19 @@
 "use client"
 import Link from "next/link"
-import { Sun, Moon } from "lucide-react"
+import { Sun, Moon, Menu as MenuIcon } from "lucide-react"
+import { Popover } from "@base-ui/react/popover"
 import { useTheme } from "next-themes"
 import { data } from "@/app/data"
 import { usePathname } from "next/navigation"
 import GitHubButton from "./github-button"
 import { useEffect, useState } from "react"
 import Image from "next/image"
+
+const navLinks = [
+  { href: "/docs/getting-started", label: "Docs", match: "/docs" },
+  { href: "/blogs", label: "Blog", match: "/blogs" },
+  { href: "/updates", label: "Updates", match: "/updates" },
+]
 
 export default function Header() {
   const { theme, setTheme } = useTheme()
@@ -18,148 +25,100 @@ export default function Header() {
     setMounted(true)
   }, [])
 
-  const toggleDarkMode = () => {
-    if (theme === "dark") {
-      setTheme("light")
-    } else {
-      setTheme("dark")
-    }
-  }
+  const toggleDarkMode = () => setTheme(theme === "dark" ? "light" : "dark")
 
-  const isActive = (path: string) => pathname === path
+  const isActive = (path: string) =>
+    pathname === path || pathname?.startsWith(`${path}/`)
+
+  const linkClass = (match: string) =>
+    isActive(match)
+      ? "text-gray-900 dark:text-white font-semibold"
+      : "text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white transition-colors"
 
   return (
-    <header className="sticky top-0 z-50 backdrop-blur-md bg-white/80 dark:bg-gray-900/80 border-b border-gray-200 dark:border-gray-800">
+    <header className="sticky top-0 z-50 glass border-b border-black/5 dark:border-white/10">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center py-4">
-          <div className="flex items-center space-x-2">
-            <Link href="/" className="flex items-center space-x-2">
-              <Image
-                src="/logo.png"
-                alt="Logo"
-                width={32}
-                height={32}
-                className="h-8 w-8"
-              />
-              <span className="text-xl font-bold">Vision AI Label Studio</span>
-            </Link>
-          </div>
+          <Link href="/" className="flex items-center space-x-2">
+            <Image
+              src="/logo.png"
+              alt="Logo"
+              width={32}
+              height={32}
+              className="h-8 w-8"
+            />
+            <span className="text-xl font-bold text-gradient">
+              Vision AI Label Studio
+            </span>
+          </Link>
+
           {/* Desktop nav */}
-          <div className="hidden md:flex items-center space-x-4">
-            <Link
-              href="/docs/getting-started"
-              className={`${
-                isActive("/docs")
-                  ? "text-gray-900 dark:text-white font-semibold"
-                  : "text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-              }`}
-            >
-              Docs
-            </Link>
-            <Link
-              href="/blogs"
-              className={`${
-                isActive("/blogs")
-                  ? "text-gray-900 dark:text-white font-semibold"
-                  : "text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-              }`}
-            >
-              Blog
-            </Link>
-            <Link
-              href="/updates"
-              className={`${
-                isActive("/updates")
-                  ? "text-gray-900 dark:text-white font-semibold"
-                  : "text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-              }`}
-            >
-              Updates
-            </Link>
+          <div className="hidden md:flex items-center space-x-6">
+            {navLinks.map((link) => (
+              <Link key={link.href} href={link.href} className={linkClass(link.match)}>
+                {link.label}
+              </Link>
+            ))}
             <GitHubButton repoUrl={data.repoUrl} />
             {mounted && (
               <button
                 onClick={toggleDarkMode}
-                className="p-2 rounded-full bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-700 transition-colors"
+                className="p-2 rounded-full glass text-gray-700 dark:text-gray-300 hover:shadow-md transition-shadow"
                 aria-label="Toggle dark mode"
               >
                 {theme === "dark" ? <Sun size={18} /> : <Moon size={18} />}
               </button>
             )}
           </div>
+
           {/* Mobile nav */}
           <div className="md:hidden flex items-center">
-            <button
-              onClick={() => setMenuOpen(!menuOpen)}
-              className="p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-gray-400"
-              aria-label="Toggle menu"
-            >
-              <svg
-                width="24"
-                height="24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="h-6 w-6"
+            <Popover.Root open={menuOpen} onOpenChange={setMenuOpen}>
+              <Popover.Trigger
+                className="p-2 rounded-md text-gray-700 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+                aria-label="Toggle menu"
               >
-                <path d="M4 6h16M4 12h16M4 18h16" />
-              </svg>
-            </button>
+                <MenuIcon className="h-6 w-6" />
+              </Popover.Trigger>
+              <Popover.Portal>
+                <Popover.Positioner
+                  side="bottom"
+                  align="end"
+                  sideOffset={8}
+                  className="z-50"
+                >
+                  <Popover.Popup className="glass rounded-2xl shadow-xl p-4 w-56 flex flex-col gap-2 animate-fade-in">
+                    {navLinks.map((link) => (
+                      <Link
+                        key={link.href}
+                        href={link.href}
+                        className={linkClass(link.match)}
+                        onClick={() => setMenuOpen(false)}
+                      >
+                        {link.label}
+                      </Link>
+                    ))}
+                    <div className="pt-2 border-t border-black/5 dark:border-white/10">
+                      <GitHubButton repoUrl={data.repoUrl} />
+                    </div>
+                    {mounted && (
+                      <button
+                        onClick={toggleDarkMode}
+                        className="mt-1 flex items-center gap-2 p-2 rounded-lg text-gray-700 dark:text-gray-300 hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
+                        aria-label="Toggle dark mode"
+                      >
+                        {theme === "dark" ? <Sun size={18} /> : <Moon size={18} />}
+                        <span className="text-sm">
+                          {theme === "dark" ? "Light mode" : "Dark mode"}
+                        </span>
+                      </button>
+                    )}
+                  </Popover.Popup>
+                </Popover.Positioner>
+              </Popover.Portal>
+            </Popover.Root>
           </div>
         </div>
-        {/* Mobile menu dropdown */}
-        {menuOpen && (
-          <div className="md:hidden flex flex-col space-y-2 pb-4 animate-fade-in">
-            <Link
-              href="/docs/getting-started"
-              className={`$${
-                isActive("/docs")
-                  ? "text-gray-900 dark:text-white font-semibold"
-                  : "text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-              }`}
-              onClick={() => setMenuOpen(false)}
-            >
-              Docs
-            </Link>
-            <Link
-              href="/blogs"
-              className={`$${
-                isActive("/blogs")
-                  ? "text-gray-900 dark:text-white font-semibold"
-                  : "text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-              }`}
-              onClick={() => setMenuOpen(false)}
-            >
-              Blog
-            </Link>
-            <Link
-              href="/updates"
-              className={`$${
-                isActive("/updates")
-                  ? "text-gray-900 dark:text-white font-semibold"
-                  : "text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-              }`}
-              onClick={() => setMenuOpen(false)}
-            >
-              Updates
-            </Link>
-            <GitHubButton repoUrl={data.repoUrl} />
-            {mounted && (
-              <div className="flex justify-center mt-4 mb-2">
-                <button
-                  onClick={toggleDarkMode}
-                  className="p-3 rounded-full bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-700 transition-colors"
-                  aria-label="Toggle dark mode"
-                  style={{ minWidth: 48, minHeight: 48 }}
-                >
-                  {theme === "dark" ? <Sun size={20} /> : <Moon size={20} />}
-                </button>
-              </div>
-            )}
-          </div>
-        )}
       </div>
     </header>
   )

--- a/apps/web/components/hero-section.tsx
+++ b/apps/web/components/hero-section.tsx
@@ -11,8 +11,9 @@ const HeroSection = () => {
   const { activeToolIndex, setActiveToolIndex, controls } = useToolAnimation()
 
   return (
-    <section className="py-16 md:py-24 overflow-hidden" id="download">
-      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+    <section className="relative py-20 md:py-28 overflow-hidden" id="download">
+      <div className="cloud-aurora" aria-hidden="true" />
+      <div className="relative z-10 container mx-auto px-4 sm:px-6 lg:px-8">
         <motion.div
           className="text-center max-w-4xl mx-auto"
           initial={{ opacity: 0, y: 20 }}

--- a/apps/web/components/hero-section.tsx
+++ b/apps/web/components/hero-section.tsx
@@ -11,9 +11,8 @@ const HeroSection = () => {
   const { activeToolIndex, setActiveToolIndex, controls } = useToolAnimation()
 
   return (
-    <section className="relative py-20 md:py-28 overflow-hidden" id="download">
-      <div className="cloud-aurora" aria-hidden="true" />
-      <div className="relative z-10 container mx-auto px-4 sm:px-6 lg:px-8">
+    <section className="py-20 md:py-28 overflow-hidden" id="download">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <motion.div
           className="text-center max-w-4xl mx-auto"
           initial={{ opacity: 0, y: 20 }}

--- a/apps/web/components/hero/hero-intro.tsx
+++ b/apps/web/components/hero/hero-intro.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { motion } from "framer-motion"
-import { ArrowRight } from "lucide-react"
+import { ArrowRight, Sparkles } from "lucide-react"
 import { GithubIcon } from "@/components/icons/github-icon"
 import { data } from "@/app/data"
 import DownloadButton from "@/components/download-button"
@@ -9,28 +9,34 @@ import DownloadButton from "@/components/download-button"
 export function HeroIntro() {
   return (
     <>
-      <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold mb-6 bg-clip-text text-transparent bg-gradient-to-r from-blue-600 to-indigo-500">
-        Vision AI Label Studio
+      <div className="flex justify-center mb-6">
+        <span className="glass inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 shadow-sm">
+          <Sparkles size={14} className="text-indigo-500" />
+          Open-source · AI-assisted · Offline-first
+        </span>
+      </div>
+      <h1 className="text-4xl md:text-6xl lg:text-7xl font-extrabold tracking-tight mb-6">
+        <span className="text-gradient">Vision AI Label Studio</span>
       </h1>
-      <p className="text-xl md:text-2xl text-gray-600 dark:text-gray-400 mb-8">
-        Label smarter and faster with AI-assisted annotations, beautiful UI, and
-        full offline support.
+      <p className="text-xl md:text-2xl text-gray-600 dark:text-gray-400 mb-10 max-w-2xl mx-auto">
+        Label smarter and faster with AI-assisted annotations, a beautiful UI,
+        and full offline support.
       </p>
-      <div className="flex flex-col sm:flex-row justify-center gap-4 mb-12 relative">
+      <div className="flex flex-col sm:flex-row justify-center items-center gap-4 mb-12 relative">
         <motion.a
           href={data.productionUrl}
-          className="px-8 py-3 rounded-lg bg-blue-600 text-white font-medium hover:bg-blue-700 transition-colors flex items-center justify-center gap-2"
-          whileHover={{ scale: 1.05 }}
-          whileTap={{ scale: 0.95 }}
+          className="px-8 py-3.5 rounded-xl bg-gradient-to-r from-blue-600 to-indigo-600 text-white font-semibold shadow-lg shadow-blue-500/25 hover:shadow-xl hover:shadow-blue-500/30 transition-shadow flex items-center justify-center gap-2"
+          whileHover={{ scale: 1.04 }}
+          whileTap={{ scale: 0.96 }}
         >
           Get Started <ArrowRight size={18} />
         </motion.a>
         <DownloadButton />
         <motion.a
           href={data.repoUrl}
-          className="px-8 py-3 rounded-lg bg-gray-200 dark:bg-gray-800 text-gray-900 dark:text-gray-100 font-medium hover:bg-gray-300 dark:hover:bg-gray-700 transition-colors flex items-center justify-center gap-2"
-          whileHover={{ scale: 1.05 }}
-          whileTap={{ scale: 0.95 }}
+          className="glass px-8 py-3.5 rounded-xl text-gray-900 dark:text-gray-100 font-semibold hover:shadow-md transition-shadow flex items-center justify-center gap-2"
+          whileHover={{ scale: 1.04 }}
+          whileTap={{ scale: 0.96 }}
         >
           <GithubIcon size={18} /> View on GitHub
         </motion.a>

--- a/apps/web/components/hero/hero-intro.tsx
+++ b/apps/web/components/hero/hero-intro.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { motion } from "framer-motion"
-import { ArrowRight, Sparkles } from "lucide-react"
+import { Sparkles } from "lucide-react"
 import { GithubIcon } from "@/components/icons/github-icon"
 import { data } from "@/app/data"
 import DownloadButton from "@/components/download-button"
@@ -10,31 +10,23 @@ export function HeroIntro() {
   return (
     <>
       <div className="flex justify-center mb-6">
-        <span className="glass inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 shadow-sm">
-          <Sparkles size={14} className="text-indigo-500" />
+        <span className="surface inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 shadow-sm">
+          <Sparkles size={14} className="text-blue-500" />
           Open-source · AI-assisted · Offline-first
         </span>
       </div>
-      <h1 className="text-4xl md:text-6xl lg:text-7xl font-extrabold tracking-tight mb-6">
-        <span className="text-gradient">Vision AI Label Studio</span>
+      <h1 className="text-4xl md:text-6xl lg:text-7xl font-extrabold tracking-tight mb-6 text-gray-900 dark:text-white">
+        Vision AI Label Studio
       </h1>
       <p className="text-xl md:text-2xl text-gray-600 dark:text-gray-400 mb-10 max-w-2xl mx-auto">
-        Label smarter and faster with AI-assisted annotations, a beautiful UI,
-        and full offline support.
+        Label smarter and faster with AI-assisted annotations, a clean UI, and
+        full offline support.
       </p>
       <div className="flex flex-col sm:flex-row justify-center items-center gap-4 mb-12 relative">
-        <motion.a
-          href={data.productionUrl}
-          className="px-8 py-3.5 rounded-xl bg-gradient-to-r from-blue-600 to-indigo-600 text-white font-semibold shadow-lg shadow-blue-500/25 hover:shadow-xl hover:shadow-blue-500/30 transition-shadow flex items-center justify-center gap-2"
-          whileHover={{ scale: 1.04 }}
-          whileTap={{ scale: 0.96 }}
-        >
-          Get Started <ArrowRight size={18} />
-        </motion.a>
         <DownloadButton />
         <motion.a
           href={data.repoUrl}
-          className="glass px-8 py-3.5 rounded-xl text-gray-900 dark:text-gray-100 font-semibold hover:shadow-md transition-shadow flex items-center justify-center gap-2"
+          className="surface px-8 py-3.5 rounded-xl text-gray-900 dark:text-gray-100 font-semibold hover:shadow-md transition-shadow flex items-center justify-center gap-2"
           whileHover={{ scale: 1.04 }}
           whileTap={{ scale: 0.96 }}
         >

--- a/apps/web/components/hero/hero-tools.tsx
+++ b/apps/web/components/hero/hero-tools.tsx
@@ -37,7 +37,8 @@ export const labelingTools: LabelingTool[] = [
     icon: <Wand2 className="w-5 h-5" />,
     image: "/demo-warehouse.svg",
     color: "bg-amber-500",
-    description: "Auto-label with YOLOv8 AI detection for 5x faster workflow",
+    description:
+      "Auto-label with local ONNX models (YOLO-family), GPU-accelerated",
   },
   {
     name: "Layer Manager",

--- a/apps/web/components/hero/labeling-canvas.tsx
+++ b/apps/web/components/hero/labeling-canvas.tsx
@@ -114,7 +114,7 @@ export function LabelingCanvas({
             initial={{ opacity: 0, scale: 0.8 }}
             animate={controls.ai}
           >
-            <div className="w-full h-full bg-gradient-to-r from-amber-500/10 to-amber-500/30 rounded-full flex items-center justify-center">
+            <div className="w-full h-full bg-amber-500/20 rounded-full flex items-center justify-center">
               <Wand2 className="w-16 h-16 text-amber-500" />
             </div>
           </motion.div>
@@ -152,7 +152,7 @@ export function LabelingCanvas({
           </motion.div>
         </div>
 
-        <div className="absolute inset-0 bg-gradient-to-t from-gray-900/30 to-transparent"></div>
+        <div className="absolute inset-0 bg-gray-900/15"></div>
       </div>
 
       {/* Interface Controls Mockup */}

--- a/apps/web/components/roadmap-section.tsx
+++ b/apps/web/components/roadmap-section.tsx
@@ -2,12 +2,74 @@
 
 import { container, item } from "@/lib/motion"
 import { motion } from "framer-motion"
-import { Check, Clock } from "lucide-react"
+import { Check, Clock, Circle, type LucideIcon } from "lucide-react"
 import React from "react"
+
+type Status = "done" | "progress" | "planned"
+
+const statusIcon: Record<Status, LucideIcon> = {
+  done: Check,
+  progress: Clock,
+  planned: Circle,
+}
+
+const columns: {
+  status: Status
+  title: string
+  dot: string
+  tint: string
+  items: { title: string; description: string }[]
+}[] = [
+  {
+    status: "done",
+    title: "Completed",
+    dot: "bg-green-500",
+    tint: "bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400",
+    items: [
+      {
+        title: "Annotation tools",
+        description: "Boxes, polygons, points, lines, circles, free-draw",
+      },
+      {
+        title: "AI-assisted labeling",
+        description: "Local ONNX models (YOLO-family)",
+      },
+      {
+        title: "Multi-format export",
+        description: "LabelMe, COCO, YOLO, Pascal VOC",
+      },
+    ],
+  },
+  {
+    status: "progress",
+    title: "In Progress",
+    dot: "bg-yellow-500",
+    tint: "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-600 dark:text-yellow-400",
+    items: [
+      { title: "Video annotation", description: "Frame-by-frame labeling" },
+      {
+        title: "Dataset intelligence",
+        description: "Quality insights & analytics",
+      },
+      { title: "Cloud storage", description: "S3, Azure, and GCS buckets" },
+    ],
+  },
+  {
+    status: "planned",
+    title: "Planned",
+    dot: "bg-blue-500",
+    tint: "bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400",
+    items: [
+      { title: "Team collaboration", description: "Multi-user projects" },
+      { title: "Active learning", description: "Model-in-the-loop labeling" },
+      { title: "Cloud sync", description: "Optional project backup" },
+    ],
+  },
+]
 
 const RoadmapSection = () => {
   return (
-    <section className="py-16">
+    <section className="py-20">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <motion.div
           className="text-center mb-16"
@@ -17,10 +79,11 @@ const RoadmapSection = () => {
           transition={{ duration: 0.5 }}
         >
           <h2 className="text-3xl md:text-5xl font-bold tracking-tight mb-4">
-            <span className="text-gradient">Roadmap</span>
+            <span className="brand-accent">Roadmap</span>
           </h2>
           <p className="text-xl text-gray-600 dark:text-gray-400 max-w-3xl mx-auto">
-            See what's completed, in progress, and planned for future releases
+            See what&apos;s completed, in progress, and planned for future
+            releases
           </p>
         </motion.div>
 
@@ -32,195 +95,40 @@ const RoadmapSection = () => {
             whileInView="show"
             viewport={{ once: true }}
           >
-            {/* Completed */}
-            <motion.div variants={item} className="space-y-4">
-              <div className="flex items-center gap-2 mb-4">
-                <div className="w-6 h-6 rounded-full bg-green-500 flex items-center justify-center text-white">
-                  <Check size={14} />
-                </div>
-                <h3 className="font-bold text-lg">Completed</h3>
-              </div>
+            {columns.map((col) => {
+              const Icon = statusIcon[col.status]
+              return (
+                <motion.div key={col.title} variants={item} className="space-y-4">
+                  <div className="flex items-center gap-2 mb-4">
+                    <div
+                      className={`w-6 h-6 rounded-full flex items-center justify-center text-white ${col.dot}`}
+                    >
+                      <Icon size={14} />
+                    </div>
+                    <h3 className="font-bold text-lg">{col.title}</h3>
+                  </div>
 
-              <div className="glass cloud-card p-3 rounded-xl flex items-start gap-2 hover:shadow-lg hover:shadow-blue-500/5">
-                <div className="w-5 h-5 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center text-green-600 dark:text-green-400 mt-0.5">
-                  <Check size={12} />
-                </div>
-                <div>
-                  <p className="font-medium">Manual Annotations</p>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    Boxes, polygons, free draw
-                  </p>
-                </div>
-              </div>
-
-              <div className="glass cloud-card p-3 rounded-xl flex items-start gap-2 hover:shadow-lg hover:shadow-blue-500/5">
-                <div className="w-5 h-5 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center text-green-600 dark:text-green-400 mt-0.5">
-                  <Check size={12} />
-                </div>
-                <div>
-                  <p className="font-medium">Offline Storage</p>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    Using Dexie.js
-                  </p>
-                </div>
-              </div>
-
-              <div className="glass cloud-card p-3 rounded-xl flex items-start gap-2 hover:shadow-lg hover:shadow-blue-500/5">
-                <div className="w-5 h-5 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center text-green-600 dark:text-green-400 mt-0.5">
-                  <Check size={12} />
-                </div>
-                <div>
-                  <p className="font-medium">YOLO Export</p>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    Standard format support
-                  </p>
-                </div>
-              </div>
-            </motion.div>
-
-            {/* In Progress */}
-            <motion.div variants={item} className="space-y-4">
-              <div className="flex items-center gap-2 mb-4">
-                <div className="w-6 h-6 rounded-full bg-yellow-500 flex items-center justify-center text-white">
-                  <Clock size={14} />
-                </div>
-                <h3 className="font-bold text-lg">In Progress</h3>
-              </div>
-
-              <div className="glass cloud-card p-3 rounded-xl flex items-start gap-2 hover:shadow-lg hover:shadow-blue-500/5">
-                <div className="w-5 h-5 rounded-full bg-yellow-100 dark:bg-yellow-900/30 flex items-center justify-center text-yellow-600 dark:text-yellow-400 mt-0.5">
-                  <Clock size={12} />
-                </div>
-                <div>
-                  <p className="font-medium">YOLOv8 Integration</p>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    AI-assisted labeling
-                  </p>
-                </div>
-              </div>
-
-              <div className="glass cloud-card p-3 rounded-xl flex items-start gap-2 hover:shadow-lg hover:shadow-blue-500/5">
-                <div className="w-5 h-5 rounded-full bg-yellow-100 dark:bg-yellow-900/30 flex items-center justify-center text-yellow-600 dark:text-yellow-400 mt-0.5">
-                  <Clock size={12} />
-                </div>
-                <div>
-                  <p className="font-medium">COCO Export</p>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    JSON format support
-                  </p>
-                </div>
-              </div>
-
-              <div className="glass cloud-card p-3 rounded-xl flex items-start gap-2 hover:shadow-lg hover:shadow-blue-500/5">
-                <div className="w-5 h-5 rounded-full bg-yellow-100 dark:bg-yellow-900/30 flex items-center justify-center text-yellow-600 dark:text-yellow-400 mt-0.5">
-                  <Clock size={12} />
-                </div>
-                <div>
-                  <p className="font-medium">Pascal VOC Export</p>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    XML format support
-                  </p>
-                </div>
-              </div>
-            </motion.div>
-
-            {/* Planned */}
-            <motion.div variants={item} className="space-y-4">
-              <div className="flex items-center gap-2 mb-4">
-                <div className="w-6 h-6 rounded-full bg-blue-500 flex items-center justify-center text-white">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={1.5}
-                    stroke="currentColor"
-                    className="w-4 h-4"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
-                    />
-                  </svg>
-                </div>
-                <h3 className="font-bold text-lg">Planned</h3>
-              </div>
-
-              <div className="glass cloud-card p-3 rounded-xl flex items-start gap-2 hover:shadow-lg hover:shadow-blue-500/5">
-                <div className="w-5 h-5 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center text-blue-600 dark:text-blue-400 mt-0.5">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={1.5}
-                    stroke="currentColor"
-                    className="w-3 h-3"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
-                    />
-                  </svg>
-                </div>
-                <div>
-                  <p className="font-medium">Video Annotation</p>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    Frame-by-frame labeling
-                  </p>
-                </div>
-              </div>
-
-              <div className="glass cloud-card p-3 rounded-xl flex items-start gap-2 hover:shadow-lg hover:shadow-blue-500/5">
-                <div className="w-5 h-5 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center text-blue-600 dark:text-blue-400 mt-0.5">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={1.5}
-                    stroke="currentColor"
-                    className="w-3 h-3"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
-                    />
-                  </svg>
-                </div>
-                <div>
-                  <p className="font-medium">Team Collaboration</p>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    Multi-user projects
-                  </p>
-                </div>
-              </div>
-
-              <div className="glass cloud-card p-3 rounded-xl flex items-start gap-2 hover:shadow-lg hover:shadow-blue-500/5">
-                <div className="w-5 h-5 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center text-blue-600 dark:text-blue-400 mt-0.5">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={1.5}
-                    stroke="currentColor"
-                    className="w-3 h-3"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
-                    />
-                  </svg>
-                </div>
-                <div>
-                  <p className="font-medium">Cloud Sync</p>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    Optional project backup
-                  </p>
-                </div>
-              </div>
-            </motion.div>
+                  {col.items.map((entry) => (
+                    <div
+                      key={entry.title}
+                      className="surface cloud-card p-3 rounded-xl flex items-start gap-2 hover:shadow-md"
+                    >
+                      <div
+                        className={`w-5 h-5 rounded-full flex items-center justify-center mt-0.5 ${col.tint}`}
+                      >
+                        <Icon size={12} />
+                      </div>
+                      <div>
+                        <p className="font-medium">{entry.title}</p>
+                        <p className="text-sm text-gray-600 dark:text-gray-400">
+                          {entry.description}
+                        </p>
+                      </div>
+                    </div>
+                  ))}
+                </motion.div>
+              )
+            })}
           </motion.div>
         </div>
       </div>

--- a/apps/web/components/roadmap-section.tsx
+++ b/apps/web/components/roadmap-section.tsx
@@ -16,7 +16,9 @@ const RoadmapSection = () => {
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
-          <h2 className="text-3xl md:text-4xl font-bold mb-4">Roadmap</h2>
+          <h2 className="text-3xl md:text-5xl font-bold tracking-tight mb-4">
+            <span className="text-gradient">Roadmap</span>
+          </h2>
           <p className="text-xl text-gray-600 dark:text-gray-400 max-w-3xl mx-auto">
             See what's completed, in progress, and planned for future releases
           </p>
@@ -39,7 +41,7 @@ const RoadmapSection = () => {
                 <h3 className="font-bold text-lg">Completed</h3>
               </div>
 
-              <div className="bg-white dark:bg-gray-800 p-3 rounded-lg border border-gray-200 dark:border-gray-700 flex items-start gap-2">
+              <div className="glass cloud-card p-3 rounded-xl flex items-start gap-2 hover:shadow-lg hover:shadow-blue-500/5">
                 <div className="w-5 h-5 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center text-green-600 dark:text-green-400 mt-0.5">
                   <Check size={12} />
                 </div>
@@ -51,7 +53,7 @@ const RoadmapSection = () => {
                 </div>
               </div>
 
-              <div className="bg-white dark:bg-gray-800 p-3 rounded-lg border border-gray-200 dark:border-gray-700 flex items-start gap-2">
+              <div className="glass cloud-card p-3 rounded-xl flex items-start gap-2 hover:shadow-lg hover:shadow-blue-500/5">
                 <div className="w-5 h-5 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center text-green-600 dark:text-green-400 mt-0.5">
                   <Check size={12} />
                 </div>
@@ -63,7 +65,7 @@ const RoadmapSection = () => {
                 </div>
               </div>
 
-              <div className="bg-white dark:bg-gray-800 p-3 rounded-lg border border-gray-200 dark:border-gray-700 flex items-start gap-2">
+              <div className="glass cloud-card p-3 rounded-xl flex items-start gap-2 hover:shadow-lg hover:shadow-blue-500/5">
                 <div className="w-5 h-5 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center text-green-600 dark:text-green-400 mt-0.5">
                   <Check size={12} />
                 </div>
@@ -85,7 +87,7 @@ const RoadmapSection = () => {
                 <h3 className="font-bold text-lg">In Progress</h3>
               </div>
 
-              <div className="bg-white dark:bg-gray-800 p-3 rounded-lg border border-gray-200 dark:border-gray-700 flex items-start gap-2">
+              <div className="glass cloud-card p-3 rounded-xl flex items-start gap-2 hover:shadow-lg hover:shadow-blue-500/5">
                 <div className="w-5 h-5 rounded-full bg-yellow-100 dark:bg-yellow-900/30 flex items-center justify-center text-yellow-600 dark:text-yellow-400 mt-0.5">
                   <Clock size={12} />
                 </div>
@@ -97,7 +99,7 @@ const RoadmapSection = () => {
                 </div>
               </div>
 
-              <div className="bg-white dark:bg-gray-800 p-3 rounded-lg border border-gray-200 dark:border-gray-700 flex items-start gap-2">
+              <div className="glass cloud-card p-3 rounded-xl flex items-start gap-2 hover:shadow-lg hover:shadow-blue-500/5">
                 <div className="w-5 h-5 rounded-full bg-yellow-100 dark:bg-yellow-900/30 flex items-center justify-center text-yellow-600 dark:text-yellow-400 mt-0.5">
                   <Clock size={12} />
                 </div>
@@ -109,7 +111,7 @@ const RoadmapSection = () => {
                 </div>
               </div>
 
-              <div className="bg-white dark:bg-gray-800 p-3 rounded-lg border border-gray-200 dark:border-gray-700 flex items-start gap-2">
+              <div className="glass cloud-card p-3 rounded-xl flex items-start gap-2 hover:shadow-lg hover:shadow-blue-500/5">
                 <div className="w-5 h-5 rounded-full bg-yellow-100 dark:bg-yellow-900/30 flex items-center justify-center text-yellow-600 dark:text-yellow-400 mt-0.5">
                   <Clock size={12} />
                 </div>
@@ -144,7 +146,7 @@ const RoadmapSection = () => {
                 <h3 className="font-bold text-lg">Planned</h3>
               </div>
 
-              <div className="bg-white dark:bg-gray-800 p-3 rounded-lg border border-gray-200 dark:border-gray-700 flex items-start gap-2">
+              <div className="glass cloud-card p-3 rounded-xl flex items-start gap-2 hover:shadow-lg hover:shadow-blue-500/5">
                 <div className="w-5 h-5 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center text-blue-600 dark:text-blue-400 mt-0.5">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
@@ -169,7 +171,7 @@ const RoadmapSection = () => {
                 </div>
               </div>
 
-              <div className="bg-white dark:bg-gray-800 p-3 rounded-lg border border-gray-200 dark:border-gray-700 flex items-start gap-2">
+              <div className="glass cloud-card p-3 rounded-xl flex items-start gap-2 hover:shadow-lg hover:shadow-blue-500/5">
                 <div className="w-5 h-5 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center text-blue-600 dark:text-blue-400 mt-0.5">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
@@ -194,7 +196,7 @@ const RoadmapSection = () => {
                 </div>
               </div>
 
-              <div className="bg-white dark:bg-gray-800 p-3 rounded-lg border border-gray-200 dark:border-gray-700 flex items-start gap-2">
+              <div className="glass cloud-card p-3 rounded-xl flex items-start gap-2 hover:shadow-lg hover:shadow-blue-500/5">
                 <div className="w-5 h-5 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center text-blue-600 dark:text-blue-400 mt-0.5">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,scss,md}\" --ignore-path .gitignore --ignore-path .prettierignore"
   },
   "dependencies": {
+    "@base-ui/react": "^1.5.0",
     "@octokit/core": "^7.0.6",
     "@tailwindcss/typography": "latest",
     "autoprefixer": "^10.5.0",

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from "tailwindcss"
 
 const config = {
-  darkMode: ["class"],
+  darkMode: "class",
   content: [
     "./pages/**/*.{ts,tsx}",
     "./components/**/*.{ts,tsx}",


### PR DESCRIPTION
## Summary

A redesign of the marketing site's landing page: a **flat, clean** visual style (no gradients), home content rewritten to reflect **what the product actually ships today**, and the interactive nav moved to `@base-ui/react`.

> `apps/web` had **no Radix UI** to remove — it was already stripped in #226. This PR introduces a Base UI component (nav popover) and restyles the UI.

## Design — flat & clean (no gradients)
- Removed all gradients: aurora glows, gradient headings/buttons, the gradient CTA panel, gradient icon tiles, the page-background gradient, and the demo-canvas overlays.
- Design helpers in `globals.css`: `.surface` (solid card/header surface), `.brand-accent` (solid accent text), `.cloud-card` (hover lift), and a real `fade-in` keyframe (the old `animate-fade-in` was undefined).
- Solid blue accent, clean bordered cards, subtle shadows.

## Content — matches the real product
The home now reflects what actually ships (was inaccurate before):
- **Annotation tools** — boxes, polygons, points, lines, circles, free-draw
- **AI-assisted labeling** — local **ONNX** models (YOLO-family), GPU-accelerated, offline *(was "YOLOv8 cloud")*
- **Multi-format export** — LabelMe, COCO, YOLO, Pascal VOC
- **Local-first & offline** — projects in **SQLite** *(was wrongly "Dexie.js")*
- **Cloud storage** — optional S3 / Azure / GCS
- **Cross-platform desktop** — Windows/macOS/Linux (Tauri)
- Roadmap updated to current status; hero AI copy de-fabricated (dropped "5x faster").

## Removed the "Get Started" button
There is **no web version** (`Get Started` pointed at a non-existent hosted app). The site is now **download-only** — the Download button + GitHub link remain.

## Base UI
- Added `@base-ui/react` (already in the lockfile via studio → **no `yarn.lock` change**).
- Mobile nav converted to an accessible Base UI `Popover` (focus management, Escape, outside-click).

## Also
- Fixed Tailwind v4 `darkMode` typing (`"class"` not `["class"]`).

## Scope
Landing page + shared header/footer. Docs/blogs/updates page bodies unchanged.

## Verification
- `tsc --noEmit` clean (except the pre-existing markdown-renderer plugin-type error)
- `next build` passes — all 7 routes generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)