### PR TITLE
refactor(video): move the video pipeline into the vailabel-video crate

### DIFF
--- a/apps/studio/src-tauri/crates/arch-tests/tests/dependency_rules.rs
+++ b/apps/studio/src-tauri/crates/arch-tests/tests/dependency_rules.rs
@@ -16,16 +16,16 @@ use std::path::{Path, PathBuf};
 
 /// Crates whose ENTIRE `src/` must be infrastructure-free.
 const FULLY_PURE: &[&str] = &[
-    "core", "shared", "plugin", "analysis", "video", "models", "copilot", "search",
+    "core", "shared", "plugin", "analysis", "models", "copilot", "search",
 ];
 
-/// Module crates that own an `infrastructure/` layer (typed Diesel, or — for
-/// `cloud` — an OpenDAL object store). Their `domain`/`application`/`contracts`
-/// layers must stay pure; `infrastructure/` legitimately depends on its backing
-/// technology (diesel + `vailabel-db`, or opendal + `std::fs`), so it is scanned
-/// at folder granularity and its `Cargo.toml` is exempt from the dependency
-/// check.
-const LAYERED: &[&str] = &["project", "dataset", "annotation", "training", "cloud"];
+/// Module crates that own an `infrastructure/` layer (typed Diesel; for `cloud`
+/// an OpenDAL object store; for `video` the FFmpeg CLI). Their
+/// `domain`/`application`/`contracts` layers must stay pure; `infrastructure/`
+/// legitimately depends on its backing technology (diesel + `vailabel-db`,
+/// opendal + `std::fs`, or `std::process` + `std::fs`), so it is scanned at
+/// folder granularity and its `Cargo.toml` is exempt from the dependency check.
+const LAYERED: &[&str] = &["project", "dataset", "annotation", "training", "cloud", "video"];
 
 /// The layers of a LAYERED crate that must remain pure.
 const PURE_LAYERS: &[&str] = &["domain", "application", "contracts"];

--- a/apps/studio/src-tauri/crates/video/Cargo.toml
+++ b/apps/studio/src-tauri/crates/video/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vailabel-video"
 version = "0.1.0"
 edition = "2021"
-description = "Video Annotation module: video metadata, CVAT-style keyframe tracks, ingest job/progress, and request DTOs. Pure domain types (FFmpeg/decode work stays in the binary)."
+description = "Video Annotation module: video metadata, CVAT-style keyframe tracks, track interpolation, ingest orchestration, and request DTOs. Domain/application/contracts are pure; the FFmpeg CLI pipeline lives behind the VideoPipeline port in infrastructure."
 
 [lib]
 name = "vailabel_video"
@@ -11,3 +11,4 @@ name = "vailabel_video"
 vailabel-core = { workspace = true }
 vailabel-shared = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }

--- a/apps/studio/src-tauri/crates/video/src/application/mod.rs
+++ b/apps/studio/src-tauri/crates/video/src/application/mod.rs
@@ -1,0 +1,9 @@
+//! The Video application layer: the use-case service plus the ports it
+//! orchestrates (the FFmpeg pipeline and the ingest progress reporter), injected
+//! by the composition root. No FFmpeg / filesystem / Tauri knowledge.
+
+pub mod ports;
+pub mod service;
+
+pub use ports::{IngestReporter, VideoPipeline};
+pub use service::VideoAppService;

--- a/apps/studio/src-tauri/crates/video/src/application/ports.rs
+++ b/apps/studio/src-tauri/crates/video/src/application/ports.rs
@@ -1,0 +1,65 @@
+//! Ports the video use cases depend on. The composition root implements these
+//! over the FFmpeg CLI (pipeline) and the Tauri event channel (reporter); the
+//! application layer stays unaware of both.
+
+use std::path::Path;
+
+use vailabel_core::DomainResult;
+
+use crate::domain::{FfmpegInfo, FrameThumb, ProbeResult, SceneCut};
+
+/// The codec layer: FFmpeg/FFprobe availability, metadata probing, filmstrip
+/// extraction, and scene detection. Implemented in `infrastructure` by shelling
+/// out to the `ffmpeg`/`ffprobe` binaries.
+pub trait VideoPipeline: Send + Sync {
+    /// Report FFmpeg / FFprobe / CUDA availability for the UI.
+    fn info(&self) -> FfmpegInfo;
+
+    /// Is the `ffmpeg` binary runnable?
+    fn is_available(&self) -> bool;
+
+    /// Is CUDA hardware decode advertised?
+    fn has_cuda(&self) -> bool;
+
+    /// Read duration / fps / dimensions / frame count, or `None` if probing
+    /// fails (e.g. FFprobe absent — callers fall back to webview-supplied values).
+    fn probe(&self, path: &str) -> Option<ProbeResult>;
+
+    /// Extract a downscaled filmstrip at `sample_fps` into `out_dir`, reporting
+    /// determinate progress `[0,1]` through `on_progress`.
+    #[allow(clippy::too_many_arguments)]
+    fn extract_frames(
+        &self,
+        path: &str,
+        out_dir: &Path,
+        sample_fps: f64,
+        max_edge: i64,
+        duration: f64,
+        src_fps: f64,
+        use_cuda: bool,
+        on_progress: &mut dyn FnMut(f64),
+    ) -> DomainResult<Vec<FrameThumb>>;
+
+    /// Detect scene cuts (the first frame always opens scene 0).
+    fn detect_scenes(
+        &self,
+        path: &str,
+        fps: f64,
+        threshold: f64,
+        use_cuda: bool,
+    ) -> DomainResult<Vec<SceneCut>>;
+
+    /// Best-effort removal of a video's extracted-frame cache directory.
+    fn clear_frame_cache(&self, frames_dir: &Path);
+}
+
+/// Receives ingest progress so the binary can stream it to the webview and grant
+/// the asset-protocol scope for the extracted frames. Implemented at the
+/// composition root (the crate never touches Tauri).
+pub trait IngestReporter {
+    /// A stage label + overall progress `[0,1]` update.
+    fn progress(&mut self, stage: &str, progress: f64);
+
+    /// The filmstrip is on disk at `frames_dir` — grant the webview read access.
+    fn frames_ready(&mut self, frames_dir: &Path);
+}

--- a/apps/studio/src-tauri/crates/video/src/application/service.rs
+++ b/apps/studio/src-tauri/crates/video/src/application/service.rs
@@ -1,0 +1,245 @@
+//! The Video Annotation use-case service.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use serde_json::Value;
+use vailabel_core::{DomainError, DomainResult};
+use vailabel_shared::{new_id, now_iso};
+
+use crate::application::ports::{IngestReporter, VideoPipeline};
+use crate::contracts::{ExportTracksRequest, ImportVideoRequest, IngestRequest};
+use crate::domain::{interpolation, MaterializedShape, Track, Video, VideoRepository};
+
+/// Application service for Video Annotation.
+///
+/// Orchestrates the persistence ([`VideoRepository`]) and codec
+/// ([`VideoPipeline`]) ports injected by the composition root. Carries no
+/// FFmpeg / filesystem / Tauri knowledge; the ingest job lifecycle (threads +
+/// the `video://progress` event) lives in the binary, which drives
+/// [`VideoAppService::ingest`] through an [`IngestReporter`].
+pub struct VideoAppService {
+    repo: Arc<dyn VideoRepository>,
+    pipeline: Arc<dyn VideoPipeline>,
+    /// Root directory the binary chose for extracted-frame caches
+    /// (`<app_data>/video-frames`); each video gets `frames_root/<id>`.
+    frames_root: PathBuf,
+}
+
+impl VideoAppService {
+    pub fn new(
+        repo: Arc<dyn VideoRepository>,
+        pipeline: Arc<dyn VideoPipeline>,
+        frames_root: PathBuf,
+    ) -> Self {
+        Self {
+            repo,
+            pipeline,
+            frames_root,
+        }
+    }
+
+    /// Reported FFmpeg/CUDA availability for the UI.
+    pub fn ffmpeg_info(&self) -> crate::domain::FfmpegInfo {
+        self.pipeline.info()
+    }
+
+    /// Whether the `ffmpeg` binary is runnable (gates ingest).
+    pub fn pipeline_available(&self) -> bool {
+        self.pipeline.is_available()
+    }
+
+    // ── Videos ──────────────────────────────────────────────────────────────
+
+    /// Import a clip: probe metadata with FFprobe (falling back to the
+    /// webview-supplied values when FFmpeg is absent) and persist the record.
+    pub fn import_video(&self, req: ImportVideoRequest) -> DomainResult<Video> {
+        let probed = self.pipeline.probe(&req.path);
+
+        let fps = probed
+            .as_ref()
+            .map(|p| p.fps)
+            .filter(|f| *f > 0.0)
+            .or(Some(req.fps).filter(|f| *f > 0.0))
+            .unwrap_or(30.0);
+        let duration = probed
+            .as_ref()
+            .map(|p| p.duration)
+            .filter(|d| *d > 0.0)
+            .unwrap_or(req.duration);
+        let width = probed.as_ref().map(|p| p.width).unwrap_or(req.width);
+        let height = probed.as_ref().map(|p| p.height).unwrap_or(req.height);
+        let frame_count = probed
+            .as_ref()
+            .map(|p| p.frame_count)
+            .filter(|c| *c > 0)
+            .unwrap_or_else(|| (duration * fps).round() as i64)
+            .max(0);
+
+        let now = now_iso();
+        let video = Video {
+            id: new_id(),
+            project_id: req.project_id,
+            name: req.name,
+            path: req.path,
+            fps,
+            duration,
+            width,
+            height,
+            frame_count,
+            sample_fps: 0.0,
+            frames_dir: String::new(),
+            frames: Vec::new(),
+            scene_cuts: Vec::new(),
+            status: "imported".into(),
+            created_at: now.clone(),
+            updated_at: now,
+        };
+        self.repo.upsert_video(&video)?;
+        Ok(video)
+    }
+
+    /// Persist a video record (used by the binary's ingest coordinator to mark
+    /// the final ready/failed status).
+    pub fn persist_video(&self, video: &Video) -> DomainResult<()> {
+        self.repo.upsert_video(video)
+    }
+
+    pub fn list_videos(&self, project_id: &str) -> DomainResult<Vec<Value>> {
+        self.repo.list_videos(project_id)
+    }
+
+    pub fn get_video(&self, id: &str) -> DomainResult<Option<Value>> {
+        self.repo.get_video(id)
+    }
+
+    /// Fetch and deserialize a video, or `None` when absent.
+    pub fn get_video_typed(&self, id: &str) -> DomainResult<Option<Video>> {
+        match self.repo.get_video(id)? {
+            Some(value) => Ok(Some(
+                serde_json::from_value(value).map_err(|e| DomainError::repository(e.to_string()))?,
+            )),
+            None => Ok(None),
+        }
+    }
+
+    /// Delete a video: drop its extracted-frame cache, its tracks, then the row.
+    pub fn delete_video(&self, id: &str) -> DomainResult<()> {
+        self.pipeline.clear_frame_cache(&self.frames_root.join(id));
+        self.repo.delete_tracks_for_video(id)?;
+        self.repo.delete_video(id)?;
+        Ok(())
+    }
+
+    // ── Ingest (driven on a binary worker thread) ───────────────────────────
+
+    /// Run the extract + scene-detect pass, reporting progress through
+    /// `reporter`. Mutates `video` in place with the results (the caller
+    /// persists the final ready/failed state).
+    pub fn ingest(
+        &self,
+        req: &IngestRequest,
+        video: &mut Video,
+        reporter: &mut dyn IngestReporter,
+    ) -> DomainResult<()> {
+        let sample_fps = req.sample_fps.unwrap_or(2.0).clamp(0.25, 10.0);
+        let threshold = req.scene_threshold.unwrap_or(0.4).clamp(0.05, 0.95);
+        let use_cuda = req.use_cuda.unwrap_or(true) && self.pipeline.has_cuda();
+
+        video.status = "processing".into();
+        self.repo.upsert_video(video)?;
+
+        // ── Frame extraction (2%..70%) ──────────────────────────────────────
+        let frames_dir = self.frames_root.join(&video.id);
+        let frames = self.pipeline.extract_frames(
+            &video.path,
+            &frames_dir,
+            sample_fps,
+            240,
+            video.duration,
+            video.fps,
+            use_cuda,
+            &mut |fraction| reporter.progress("Extracting frames", 0.02 + fraction * 0.68),
+        )?;
+        // Let the asset protocol serve the extracted frames to the webview.
+        reporter.frames_ready(&frames_dir);
+
+        // ── Scene detection (70%..95%) ──────────────────────────────────────
+        reporter.progress("Detecting scenes", 0.72);
+        let scene_cuts = self
+            .pipeline
+            .detect_scenes(&video.path, video.fps, threshold, use_cuda)?;
+
+        // ── Stage results onto the video (caller persists) ──────────────────
+        reporter.progress("Saving", 0.97);
+        video.sample_fps = sample_fps;
+        video.frames_dir = frames_dir.to_string_lossy().to_string();
+        video.frames = frames;
+        video.scene_cuts = scene_cuts;
+        Ok(())
+    }
+
+    // ── Tracks ──────────────────────────────────────────────────────────────
+
+    pub fn save_track(&self, mut track: Track) -> DomainResult<Track> {
+        if track.id.is_empty() {
+            track.id = new_id();
+        }
+        if track.created_at.is_empty() {
+            track.created_at = now_iso();
+        }
+        track.updated_at = now_iso();
+        track.keyframes.sort_by_key(|kf| kf.frame);
+
+        self.repo.upsert_track(&track)?;
+        Ok(track)
+    }
+
+    pub fn list_tracks(&self, video_id: &str) -> DomainResult<Vec<Value>> {
+        self.repo.list_tracks(video_id)
+    }
+
+    pub fn delete_track(&self, id: &str) -> DomainResult<()> {
+        self.repo.delete_track(id)
+    }
+
+    // ── Export / materialization ────────────────────────────────────────────
+
+    /// Resolve every track's interpolated shape across a frame range — sparse
+    /// keyframe tracks → dense per-frame annotations for export.
+    pub fn export_tracks(
+        &self,
+        req: ExportTracksRequest,
+    ) -> DomainResult<Vec<MaterializedShape>> {
+        let video = self
+            .get_video_typed(&req.video_id)?
+            .ok_or_else(|| DomainError::not_found("Video"))?;
+
+        let start = req.start_frame.unwrap_or(0).max(0);
+        let end = req
+            .end_frame
+            .unwrap_or_else(|| (video.frame_count - 1).max(0));
+        let step = req.step.unwrap_or(1).max(1);
+
+        let track_values = self.repo.list_tracks(&req.video_id)?;
+        let mut out = Vec::new();
+        for value in track_values {
+            let track: Track =
+                serde_json::from_value(value).map_err(|e| DomainError::repository(e.to_string()))?;
+            for (frame, sampled) in interpolation::materialize(&track, start, end, step) {
+                out.push(MaterializedShape {
+                    track_id: track.id.clone(),
+                    label_id: track.label_id.clone(),
+                    label_name: track.label_name.clone(),
+                    color: track.color.clone(),
+                    kind: track.kind.clone(),
+                    frame,
+                    shape: sampled.shape,
+                    keyframe: sampled.keyframe,
+                    interpolated: !sampled.keyframe,
+                });
+            }
+        }
+        Ok(out)
+    }
+}

--- a/apps/studio/src-tauri/crates/video/src/domain/interpolation.rs
+++ b/apps/studio/src-tauri/crates/video/src/domain/interpolation.rs
@@ -13,7 +13,7 @@
 //!   `b`; otherwise interpolate `a → b` by the fractional position.
 //! - Interpolation requires equal point counts; mismatched shapes hold `a`.
 
-use super::model::{Point, Track, TrackKeyframe};
+use super::{Point, Track, TrackKeyframe};
 
 /// A track shape resolved at a single frame.
 pub struct SampledShape {

--- a/apps/studio/src-tauri/crates/video/src/domain/mod.rs
+++ b/apps/studio/src-tauri/crates/video/src/domain/mod.rs
@@ -6,6 +6,11 @@ use serde::{Deserialize, Serialize};
 use vailabel_core::Identifiable;
 use vailabel_shared::now_iso;
 
+pub mod interpolation;
+pub mod repository;
+
+pub use repository::VideoRepository;
+
 /// A 2D point in **image space** (same convention as image annotations).
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub struct Point {

--- a/apps/studio/src-tauri/crates/video/src/domain/repository.rs
+++ b/apps/studio/src-tauri/crates/video/src/domain/repository.rs
@@ -1,0 +1,38 @@
+//! The video persistence port.
+//!
+//! Videos and tracks are stored as JSON blobs (the frontend mirror is the source
+//! of truth for the shape). The binary implements this over its residual
+//! `DesktopStore`; the crate stays unaware of Diesel/SQLite. Reads return the raw
+//! stored [`Value`] so the JSON crossing IPC is byte-identical to what was saved.
+
+use serde_json::Value;
+use vailabel_core::DomainResult;
+
+use super::{Track, Video};
+
+/// Persistence for [`Video`]s and their [`Track`]s.
+pub trait VideoRepository: Send + Sync {
+    /// Create or replace a video record.
+    fn upsert_video(&self, video: &Video) -> DomainResult<()>;
+
+    /// All videos in a project, newest first (raw stored JSON).
+    fn list_videos(&self, project_id: &str) -> DomainResult<Vec<Value>>;
+
+    /// One video by id (raw stored JSON), or `None`.
+    fn get_video(&self, id: &str) -> DomainResult<Option<Value>>;
+
+    /// Delete a video record (tracks are removed separately).
+    fn delete_video(&self, id: &str) -> DomainResult<()>;
+
+    /// Create or replace a track record.
+    fn upsert_track(&self, track: &Track) -> DomainResult<()>;
+
+    /// All tracks for a video, oldest first (raw stored JSON).
+    fn list_tracks(&self, video_id: &str) -> DomainResult<Vec<Value>>;
+
+    /// Delete one track by id.
+    fn delete_track(&self, id: &str) -> DomainResult<()>;
+
+    /// Delete every track belonging to a video (cascade on video delete).
+    fn delete_tracks_for_video(&self, video_id: &str) -> DomainResult<()>;
+}

--- a/apps/studio/src-tauri/crates/video/src/infrastructure/ffmpeg.rs
+++ b/apps/studio/src-tauri/crates/video/src/infrastructure/ffmpeg.rs
@@ -15,10 +15,82 @@ use std::path::Path;
 use std::process::{Child, Command, Stdio};
 
 use serde_json::Value;
+use vailabel_core::{DomainError, DomainResult};
 
-use crate::AppError;
+use crate::application::ports::VideoPipeline;
+use crate::domain::{FfmpegInfo, FrameThumb, ProbeResult, SceneCut};
 
-use super::model::{FfmpegInfo, FrameThumb, ProbeResult, SceneCut};
+/// The FFmpeg-CLI implementation of the codec port.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FfmpegPipeline;
+
+impl FfmpegPipeline {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl VideoPipeline for FfmpegPipeline {
+    fn info(&self) -> FfmpegInfo {
+        info()
+    }
+
+    fn is_available(&self) -> bool {
+        is_available()
+    }
+
+    fn has_cuda(&self) -> bool {
+        has_cuda()
+    }
+
+    fn probe(&self, path: &str) -> Option<ProbeResult> {
+        probe(path).ok()
+    }
+
+    fn extract_frames(
+        &self,
+        path: &str,
+        out_dir: &Path,
+        sample_fps: f64,
+        max_edge: i64,
+        duration: f64,
+        src_fps: f64,
+        use_cuda: bool,
+        on_progress: &mut dyn FnMut(f64),
+    ) -> DomainResult<Vec<FrameThumb>> {
+        extract_frames(
+            path,
+            out_dir,
+            sample_fps,
+            max_edge,
+            duration,
+            src_fps,
+            use_cuda,
+            on_progress,
+        )
+    }
+
+    fn detect_scenes(
+        &self,
+        path: &str,
+        fps: f64,
+        threshold: f64,
+        use_cuda: bool,
+    ) -> DomainResult<Vec<SceneCut>> {
+        detect_scenes(path, fps, threshold, use_cuda)
+    }
+
+    fn clear_frame_cache(&self, frames_dir: &Path) {
+        if frames_dir.exists() {
+            let _ = std::fs::remove_dir_all(frames_dir);
+        }
+    }
+}
+
+/// Map any FFmpeg/IO failure into the domain's repository variant.
+fn repo(error: impl ToString) -> DomainError {
+    DomainError::repository(error.to_string())
+}
 
 fn ffmpeg_bin() -> String {
     std::env::var("VAILABEL_FFMPEG").unwrap_or_else(|_| "ffmpeg".to_string())
@@ -41,15 +113,15 @@ fn command(bin: &str) -> Command {
 }
 
 /// Run a command to completion, returning combined stdout (on success).
-fn run_capture(bin: &str, args: &[&str]) -> Result<String, AppError> {
+fn run_capture(bin: &str, args: &[&str]) -> DomainResult<String> {
     let output = command(bin)
         .args(args)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
-        .map_err(|err| AppError::Message(format!("Failed to launch {bin}: {err}")))?;
+        .map_err(|err| DomainError::repository(format!("Failed to launch {bin}: {err}")))?;
     if !output.status.success() {
-        return Err(AppError::Message(format!(
+        return Err(DomainError::repository(format!(
             "{bin} exited with {}: {}",
             output.status,
             String::from_utf8_lossy(&output.stderr).trim()
@@ -59,7 +131,7 @@ fn run_capture(bin: &str, args: &[&str]) -> Result<String, AppError> {
 }
 
 /// Probe FFmpeg / FFprobe availability and CUDA support for the UI.
-pub fn info() -> FfmpegInfo {
+fn info() -> FfmpegInfo {
     let version = run_capture(&ffmpeg_bin(), &["-hide_banner", "-version"])
         .ok()
         .and_then(|out| out.lines().next().map(str::to_string));
@@ -88,18 +160,18 @@ pub fn info() -> FfmpegInfo {
     }
 }
 
-pub fn is_available() -> bool {
+fn is_available() -> bool {
     run_capture(&ffmpeg_bin(), &["-hide_banner", "-version"]).is_ok()
 }
 
-pub fn has_cuda() -> bool {
+fn has_cuda() -> bool {
     run_capture(&ffmpeg_bin(), &["-hide_banner", "-hwaccels"])
         .map(|out| out.to_lowercase().contains("cuda"))
         .unwrap_or(false)
 }
 
 /// Read duration / fps / dimensions / frame count via ffprobe (JSON output).
-pub fn probe(path: &str) -> Result<ProbeResult, AppError> {
+fn probe(path: &str) -> DomainResult<ProbeResult> {
     let json = run_capture(
         &ffprobe_bin(),
         &[
@@ -112,7 +184,7 @@ pub fn probe(path: &str) -> Result<ProbeResult, AppError> {
             path,
         ],
     )?;
-    let value: Value = serde_json::from_str(&json)?;
+    let value: Value = serde_json::from_str(&json).map_err(repo)?;
 
     let stream = value
         .get("streams")
@@ -122,7 +194,7 @@ pub fn probe(path: &str) -> Result<ProbeResult, AppError> {
                 .iter()
                 .find(|s| s.get("codec_type").and_then(Value::as_str) == Some("video"))
         })
-        .ok_or_else(|| AppError::Message("No video stream found".into()))?;
+        .ok_or_else(|| DomainError::repository("No video stream found"))?;
 
     let width = stream.get("width").and_then(Value::as_i64).unwrap_or(0);
     let height = stream.get("height").and_then(Value::as_i64).unwrap_or(0);
@@ -182,12 +254,12 @@ fn parse_rational(value: &str) -> f64 {
 
 /// Detect scene cuts with FFmpeg's `select='gt(scene,T)'` filter, parsing the
 /// `showinfo` timestamps from stderr. The first frame always opens scene 0.
-pub fn detect_scenes(
+fn detect_scenes(
     path: &str,
     fps: f64,
     threshold: f64,
     use_cuda: bool,
-) -> Result<Vec<SceneCut>, AppError> {
+) -> DomainResult<Vec<SceneCut>> {
     let filter = format!(
         "scale=320:-2,select='gt(scene,{:.3})',showinfo",
         threshold.clamp(0.0, 1.0)
@@ -214,13 +286,13 @@ pub fn detect_scenes(
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .output()
-        .map_err(|err| AppError::Message(format!("Failed to launch ffmpeg: {err}")))?;
+        .map_err(|err| DomainError::repository(format!("Failed to launch ffmpeg: {err}")))?;
 
     if !output.status.success() {
         if use_cuda {
             return detect_scenes(path, fps, threshold, false);
         }
-        return Err(AppError::Message(format!(
+        return Err(DomainError::repository(format!(
             "ffmpeg scene detection failed: {}",
             String::from_utf8_lossy(&output.stderr).trim()
         )));
@@ -259,7 +331,8 @@ pub fn detect_scenes(
 /// Extract a downscaled filmstrip at `sample_fps` to `out_dir`. Reports
 /// determinate progress (0..1) by polling the output directory while FFmpeg
 /// runs. CUDA decode falls back to software on error.
-pub fn extract_frames<F: FnMut(f64)>(
+#[allow(clippy::too_many_arguments)]
+fn extract_frames(
     path: &str,
     out_dir: &Path,
     sample_fps: f64,
@@ -267,9 +340,9 @@ pub fn extract_frames<F: FnMut(f64)>(
     duration: f64,
     src_fps: f64,
     use_cuda: bool,
-    mut on_progress: F,
-) -> Result<Vec<FrameThumb>, AppError> {
-    std::fs::create_dir_all(out_dir)?;
+    on_progress: &mut dyn FnMut(f64),
+) -> DomainResult<Vec<FrameThumb>> {
+    std::fs::create_dir_all(out_dir).map_err(repo)?;
     clear_jpgs(out_dir)?;
 
     let pattern = out_dir.join("frame_%06d.jpg");
@@ -301,11 +374,11 @@ pub fn extract_frames<F: FnMut(f64)>(
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
-        .map_err(|err| AppError::Message(format!("Failed to launch ffmpeg: {err}")))?;
+        .map_err(|err| DomainError::repository(format!("Failed to launch ffmpeg: {err}")))?;
 
     let expected = ((duration * sample_fps).ceil() as usize).max(1);
     loop {
-        match child.try_wait()? {
+        match child.try_wait().map_err(repo)? {
             Some(status) => {
                 if !status.success() {
                     if use_cuda {
@@ -320,7 +393,7 @@ pub fn extract_frames<F: FnMut(f64)>(
                             on_progress,
                         );
                     }
-                    return Err(AppError::Message("ffmpeg frame extraction failed".into()));
+                    return Err(DomainError::repository("ffmpeg frame extraction failed"));
                 }
                 break;
             }
@@ -357,12 +430,12 @@ fn is_jpg(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
-fn clear_jpgs(dir: &Path) -> Result<(), AppError> {
+fn clear_jpgs(dir: &Path) -> DomainResult<()> {
     if !dir.exists() {
         return Ok(());
     }
-    for entry in std::fs::read_dir(dir)? {
-        let path = entry?.path();
+    for entry in std::fs::read_dir(dir).map_err(repo)? {
+        let path = entry.map_err(repo)?.path();
         if is_jpg(&path) {
             let _ = std::fs::remove_file(path);
         }
@@ -381,10 +454,10 @@ fn count_jpgs(dir: &Path) -> usize {
         .unwrap_or(0)
 }
 
-fn list_jpgs(dir: &Path) -> Result<Vec<std::path::PathBuf>, AppError> {
+fn list_jpgs(dir: &Path) -> DomainResult<Vec<std::path::PathBuf>> {
     let mut files = Vec::new();
-    for entry in std::fs::read_dir(dir)? {
-        let path = entry?.path();
+    for entry in std::fs::read_dir(dir).map_err(repo)? {
+        let path = entry.map_err(repo)?.path();
         if is_jpg(&path) {
             files.push(path);
         }

--- a/apps/studio/src-tauri/crates/video/src/infrastructure/mod.rs
+++ b/apps/studio/src-tauri/crates/video/src/infrastructure/mod.rs
@@ -1,0 +1,7 @@
+//! The infrastructure layer: the FFmpeg-CLI implementation of the
+//! [`crate::application::VideoPipeline`] port. The only layer allowed
+//! `std::process` / `std::fs`.
+
+pub mod ffmpeg;
+
+pub use ffmpeg::FfmpegPipeline;

--- a/apps/studio/src-tauri/crates/video/src/lib.rs
+++ b/apps/studio/src-tauri/crates/video/src/lib.rs
@@ -7,8 +7,16 @@
 //! `src/types/video.ts`; field names are camelCase so the same JSON crosses IPC
 //! unchanged.
 //!
-//! All heavy video work (decode, frame extraction, scene detection) runs in the
-//! binary by shelling out to FFmpeg — this crate holds only the pure data model.
+//! Heavy video work (decode, frame extraction, scene detection) shells out to
+//! the FFmpeg CLI; that lives behind the [`application::VideoPipeline`] port,
+//! implemented in [`infrastructure`] (the only layer allowed `std::process` /
+//! `std::fs`). Persistence is the [`domain::VideoRepository`] port, implemented
+//! by the binary over its store. The ingest job lifecycle (threads + the
+//! `video://progress` Tauri event) stays in the binary, driving the crate's
+//! [`application::VideoAppService`] through the [`application::IngestReporter`]
+//! port.
 
+pub mod application;
 pub mod contracts;
 pub mod domain;
+pub mod infrastructure;

--- a/apps/studio/src-tauri/src/domain/video/mod.rs
+++ b/apps/studio/src-tauri/src/domain/video/mod.rs
@@ -1,5 +1,4 @@
 pub mod commands;
-pub mod ffmpeg;
-pub mod interpolation;
 pub mod model;
+pub mod repository;
 pub mod service;

--- a/apps/studio/src-tauri/src/domain/video/repository.rs
+++ b/apps/studio/src-tauri/src/domain/video/repository.rs
@@ -1,0 +1,87 @@
+//! Composition-root adapter: the `vailabel-video` persistence port over the
+//! residual `DesktopStore` (the JSON-blob `videos` / `tracks` tables). Keeping
+//! the store here — rather than moving the tables into the crate — means the
+//! video migration is logic-only and low-risk; the crate stays unaware of
+//! Diesel/SQLite.
+
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use serde_json::Value;
+use vailabel_core::{DomainError, DomainResult};
+use vailabel_video::domain::{Track, Video, VideoRepository};
+
+use crate::store::DesktopStore;
+
+/// Map any store failure into the domain's repository variant.
+fn repo(error: impl ToString) -> DomainError {
+    DomainError::repository(error.to_string())
+}
+
+pub struct VideoStoreRepository {
+    store: Arc<Mutex<DesktopStore>>,
+}
+
+impl VideoStoreRepository {
+    pub fn new(store: Arc<Mutex<DesktopStore>>) -> Self {
+        Self { store }
+    }
+
+    fn guard(&self) -> DomainResult<MutexGuard<'_, DesktopStore>> {
+        self.store
+            .lock()
+            .map_err(|_| DomainError::repository("Desktop store is unavailable"))
+    }
+}
+
+impl VideoRepository for VideoStoreRepository {
+    fn upsert_video(&self, video: &Video) -> DomainResult<()> {
+        let json = serde_json::to_string(video).map_err(repo)?;
+        self.guard()?
+            .upsert_video(
+                &video.id,
+                &video.project_id,
+                &video.created_at,
+                &video.updated_at,
+                &json,
+            )
+            .map_err(repo)
+    }
+
+    fn list_videos(&self, project_id: &str) -> DomainResult<Vec<Value>> {
+        self.guard()?.list_videos(project_id).map_err(repo)
+    }
+
+    fn get_video(&self, id: &str) -> DomainResult<Option<Value>> {
+        self.guard()?.get_video(id).map_err(repo)
+    }
+
+    fn delete_video(&self, id: &str) -> DomainResult<()> {
+        self.guard()?.delete_video(id).map_err(repo)
+    }
+
+    fn upsert_track(&self, track: &Track) -> DomainResult<()> {
+        let json = serde_json::to_string(track).map_err(repo)?;
+        self.guard()?
+            .upsert_track(
+                &track.id,
+                &track.video_id,
+                &track.project_id,
+                &track.created_at,
+                &track.updated_at,
+                &json,
+            )
+            .map_err(repo)
+    }
+
+    fn list_tracks(&self, video_id: &str) -> DomainResult<Vec<Value>> {
+        self.guard()?.list_tracks(video_id).map_err(repo)
+    }
+
+    fn delete_track(&self, id: &str) -> DomainResult<()> {
+        self.guard()?.delete_track(id).map_err(repo)
+    }
+
+    fn delete_tracks_for_video(&self, video_id: &str) -> DomainResult<()> {
+        self.guard()?.delete_tracks_for_video(video_id).map_err(repo)
+    }
+}

--- a/apps/studio/src-tauri/src/domain/video/service.rs
+++ b/apps/studio/src-tauri/src/domain/video/service.rs
@@ -1,155 +1,77 @@
-//! Orchestration for Video Annotation.
+//! Ingest coordination glue for Video Annotation.
 //!
-//! Owns persistence (JSON-blob `videos` / `tracks` tables, mirroring the
-//! analysis-report store) and drives the FFmpeg pipeline. The slow ingest pass
-//! (extract filmstrip + detect scenes) runs on a detached worker thread and
-//! streams progress over `video://progress`, exactly like the Dataset
-//! Intelligence analysis service.
+//! Thin facade over the `vailabel-video` [`VideoAppService`]: CRUD/export/track
+//! calls forward straight through. The binary-only concerns of ingest stay
+//! here — the in-memory job map, the worker thread, the `video://progress`
+//! Tauri event, and the asset-protocol scope for extracted frames — delivered to
+//! the crate through the [`IngestReporter`] port. Domain errors convert to
+//! `AppError` via the `From` impl in `crate::composition`.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::path::Path;
+use std::sync::{Arc, Mutex};
 use std::thread;
 
 use serde_json::Value;
 use tauri::{AppHandle, Emitter, Manager};
 use uuid::Uuid;
 
-use crate::store::DesktopStore;
-use crate::{now_iso, AppError};
+use vailabel_video::application::{IngestReporter, VideoAppService};
+use vailabel_video::contracts::{ExportTracksRequest, ImportVideoRequest, IngestRequest};
+use vailabel_video::domain::{FfmpegInfo, MaterializedShape, Track, Video, VideoJob};
 
-use super::ffmpeg;
-use super::interpolation;
-use super::model::*;
+use crate::{now_iso, AppError};
 
 pub const PROGRESS_EVENT: &str = "video://progress";
 
 type JobMap = Arc<Mutex<HashMap<String, VideoJob>>>;
 
+/// Forwards CRUD/export to the app service; owns the ingest job lifecycle.
 #[derive(Clone)]
 pub struct VideoService {
-    store: Arc<Mutex<DesktopStore>>,
-    frames_root: PathBuf,
+    app: Arc<VideoAppService>,
     jobs: JobMap,
 }
 
 impl VideoService {
-    pub fn new(store: Arc<Mutex<DesktopStore>>, frames_root: PathBuf) -> Self {
+    pub fn new(app: Arc<VideoAppService>) -> Self {
         Self {
-            store,
-            frames_root,
+            app,
             jobs: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
-    fn guard(&self) -> Result<MutexGuard<'_, DesktopStore>, AppError> {
-        self.store
-            .lock()
-            .map_err(|_| AppError::Message("Desktop store is unavailable".into()))
-    }
-
     pub fn ffmpeg_info(&self) -> FfmpegInfo {
-        ffmpeg::info()
+        self.app.ffmpeg_info()
     }
 
     // ── Videos ────────────────────────────────────────────────────────────────
 
-    /// Import a clip: probe metadata with ffprobe (falling back to the
-    /// webview-supplied values when FFmpeg is absent) and persist the record.
     pub fn import_video(&self, req: ImportVideoRequest) -> Result<Video, AppError> {
-        let probed = ffmpeg::probe(&req.path).ok();
-
-        let fps = probed
-            .as_ref()
-            .map(|p| p.fps)
-            .filter(|f| *f > 0.0)
-            .or(Some(req.fps).filter(|f| *f > 0.0))
-            .unwrap_or(30.0);
-        let duration = probed
-            .as_ref()
-            .map(|p| p.duration)
-            .filter(|d| *d > 0.0)
-            .unwrap_or(req.duration);
-        let width = probed.as_ref().map(|p| p.width).unwrap_or(req.width);
-        let height = probed.as_ref().map(|p| p.height).unwrap_or(req.height);
-        let frame_count = probed
-            .as_ref()
-            .map(|p| p.frame_count)
-            .filter(|c| *c > 0)
-            .unwrap_or_else(|| (duration * fps).round() as i64)
-            .max(0);
-
-        let now = now_iso();
-        let video = Video {
-            id: Uuid::new_v4().to_string(),
-            project_id: req.project_id,
-            name: req.name,
-            path: req.path,
-            fps,
-            duration,
-            width,
-            height,
-            frame_count,
-            sample_fps: 0.0,
-            frames_dir: String::new(),
-            frames: Vec::new(),
-            scene_cuts: Vec::new(),
-            status: "imported".into(),
-            created_at: now.clone(),
-            updated_at: now,
-        };
-        self.persist_video(&video)?;
-        Ok(video)
-    }
-
-    fn persist_video(&self, video: &Video) -> Result<(), AppError> {
-        let json = serde_json::to_string(video)?;
-        self.guard()?.upsert_video(
-            &video.id,
-            &video.project_id,
-            &video.created_at,
-            &video.updated_at,
-            &json,
-        )?;
-        Ok(())
+        Ok(self.app.import_video(req)?)
     }
 
     pub fn list_videos(&self, project_id: &str) -> Result<Vec<Value>, AppError> {
-        Ok(self.guard()?.list_videos(project_id)?)
+        Ok(self.app.list_videos(project_id)?)
     }
 
     pub fn get_video(&self, id: &str) -> Result<Option<Value>, AppError> {
-        Ok(self.guard()?.get_video(id)?)
-    }
-
-    fn get_video_typed(&self, id: &str) -> Result<Option<Video>, AppError> {
-        match self.guard()?.get_video(id)? {
-            Some(value) => Ok(Some(serde_json::from_value(value)?)),
-            None => Ok(None),
-        }
+        Ok(self.app.get_video(id)?)
     }
 
     pub fn delete_video(&self, id: &str) -> Result<(), AppError> {
-        // Best-effort cleanup of the extracted frame cache.
-        let dir = self.frames_root.join(id);
-        if dir.exists() {
-            let _ = std::fs::remove_dir_all(&dir);
-        }
-        let store = self.guard()?;
-        store.delete_tracks_for_video(id)?;
-        store.delete_video(id)?;
-        Ok(())
+        Ok(self.app.delete_video(id)?)
     }
 
     pub fn job(&self, job_id: &str) -> Option<VideoJob> {
         self.jobs.lock().ok()?.get(job_id).cloned()
     }
 
-    // ── Ingest (FFmpeg pipeline) ──────────────────────────────────────────────
+    // ── Ingest (FFmpeg pipeline on a worker thread) ────────────────────────────
 
     /// Queue the extract + scene-detect pass on a worker thread.
     pub fn start_ingest(&self, app: &AppHandle, req: IngestRequest) -> Result<VideoJob, AppError> {
-        if !ffmpeg::is_available() {
+        if !self.app.pipeline_available() {
             return Err(AppError::Message(
                 "FFmpeg was not found. Install FFmpeg (with CUDA for GPU decode) or set \
                  VAILABEL_FFMPEG."
@@ -157,6 +79,7 @@ impl VideoService {
             ));
         }
         let video = self
+            .app
             .get_video_typed(&req.video_id)?
             .ok_or_else(|| AppError::Message("Video not found".into()))?;
 
@@ -178,11 +101,25 @@ impl VideoService {
     }
 
     fn run_ingest(&self, app: &AppHandle, req: IngestRequest, mut video: Video, job_id: String) {
-        match self.ingest_inner(app, &req, &mut video, &job_id) {
+        // Mark running before the heavy work (the app service reports the
+        // per-stage progress from here on through the reporter).
+        self.update_job(app, &job_id, |job| {
+            job.status = "running".into();
+            job.stage = "Extracting frames".into();
+            job.progress = 0.02;
+        });
+
+        let mut reporter = TauriIngestReporter {
+            service: self.clone(),
+            app: app.clone(),
+            job_id: job_id.clone(),
+        };
+
+        match self.app.ingest(&req, &mut video, &mut reporter) {
             Ok(()) => {
                 video.status = "ready".into();
                 video.updated_at = now_iso();
-                let _ = self.persist_video(&video);
+                let _ = self.app.persist_video(&video);
                 self.update_job(app, &job_id, |job| {
                     job.status = "completed".into();
                     job.stage = "Ready".into();
@@ -192,7 +129,7 @@ impl VideoService {
             Err(err) => {
                 video.status = "failed".into();
                 video.updated_at = now_iso();
-                let _ = self.persist_video(&video);
+                let _ = self.app.persist_video(&video);
                 self.update_job(app, &job_id, |job| {
                     job.status = "failed".into();
                     job.stage = "Failed".into();
@@ -200,70 +137,6 @@ impl VideoService {
                 });
             }
         }
-    }
-
-    fn ingest_inner(
-        &self,
-        app: &AppHandle,
-        req: &IngestRequest,
-        video: &mut Video,
-        job_id: &str,
-    ) -> Result<(), AppError> {
-        let sample_fps = req.sample_fps.unwrap_or(2.0).clamp(0.25, 10.0);
-        let threshold = req.scene_threshold.unwrap_or(0.4).clamp(0.05, 0.95);
-        let use_cuda = req.use_cuda.unwrap_or(true) && ffmpeg::has_cuda();
-
-        video.status = "processing".into();
-        let _ = self.persist_video(video);
-        self.update_job(app, job_id, |job| {
-            job.status = "running".into();
-            job.stage = "Extracting frames".into();
-            job.progress = 0.02;
-        });
-
-        // ── Frame extraction (0%..70%) ──────────────────────────────────────
-        let frames_dir = self.frames_root.join(&video.id);
-        let app_for_progress = app.clone();
-        let job_for_progress = job_id.to_string();
-        let service = self.clone();
-        let frames = ffmpeg::extract_frames(
-            &video.path,
-            &frames_dir,
-            sample_fps,
-            240,
-            video.duration,
-            video.fps,
-            use_cuda,
-            move |fraction| {
-                service.update_job(&app_for_progress, &job_for_progress, |job| {
-                    job.stage = "Extracting frames".into();
-                    job.progress = 0.02 + fraction * 0.68;
-                });
-            },
-        )?;
-
-        // Let the asset protocol serve the extracted frames to the webview.
-        let _ = app
-            .asset_protocol_scope()
-            .allow_directory(&frames_dir, true);
-
-        // ── Scene detection (70%..95%) ──────────────────────────────────────
-        self.update_job(app, job_id, |job| {
-            job.stage = "Detecting scenes".into();
-            job.progress = 0.72;
-        });
-        let scene_cuts = ffmpeg::detect_scenes(&video.path, video.fps, threshold, use_cuda)?;
-
-        // ── Persist ─────────────────────────────────────────────────────────
-        self.update_job(app, job_id, |job| {
-            job.stage = "Saving".into();
-            job.progress = 0.97;
-        });
-        video.sample_fps = sample_fps;
-        video.frames_dir = frames_dir.to_string_lossy().to_string();
-        video.frames = frames;
-        video.scene_cuts = scene_cuts;
-        Ok(())
     }
 
     fn update_job<F: FnOnce(&mut VideoJob)>(&self, app: &AppHandle, job_id: &str, mutate: F) {
@@ -284,73 +157,50 @@ impl VideoService {
 
     // ── Tracks ────────────────────────────────────────────────────────────────
 
-    pub fn save_track(&self, mut track: Track) -> Result<Track, AppError> {
-        if track.id.is_empty() {
-            track.id = Uuid::new_v4().to_string();
-        }
-        if track.created_at.is_empty() {
-            track.created_at = now_iso();
-        }
-        track.updated_at = now_iso();
-        track.keyframes.sort_by_key(|kf| kf.frame);
-
-        let json = serde_json::to_string(&track)?;
-        self.guard()?.upsert_track(
-            &track.id,
-            &track.video_id,
-            &track.project_id,
-            &track.created_at,
-            &track.updated_at,
-            &json,
-        )?;
-        Ok(track)
+    pub fn save_track(&self, track: Track) -> Result<Track, AppError> {
+        Ok(self.app.save_track(track)?)
     }
 
     pub fn list_tracks(&self, video_id: &str) -> Result<Vec<Value>, AppError> {
-        Ok(self.guard()?.list_tracks(video_id)?)
+        Ok(self.app.list_tracks(video_id)?)
     }
 
     pub fn delete_track(&self, id: &str) -> Result<(), AppError> {
-        self.guard()?.delete_track(id)?;
-        Ok(())
+        Ok(self.app.delete_track(id)?)
     }
 
     // ── Export / materialization ──────────────────────────────────────────────
 
-    /// Resolve every track's interpolated shape across a frame range — sparse
-    /// keyframe tracks → dense per-frame annotations for export.
     pub fn export_tracks(
         &self,
         req: ExportTracksRequest,
     ) -> Result<Vec<MaterializedShape>, AppError> {
-        let video = self
-            .get_video_typed(&req.video_id)?
-            .ok_or_else(|| AppError::Message("Video not found".into()))?;
+        Ok(self.app.export_tracks(req)?)
+    }
+}
 
-        let start = req.start_frame.unwrap_or(0).max(0);
-        let end = req
-            .end_frame
-            .unwrap_or_else(|| (video.frame_count - 1).max(0));
-        let step = req.step.unwrap_or(1).max(1);
+/// Bridges the crate's ingest progress to the webview: job-map updates streamed
+/// over `video://progress`, plus granting the asset-protocol scope so the
+/// extracted frames load.
+struct TauriIngestReporter {
+    service: VideoService,
+    app: AppHandle,
+    job_id: String,
+}
 
-        let track_values = self.guard()?.list_tracks(&req.video_id)?;
-        let mut out = Vec::new();
-        for value in track_values {
-            let track: Track = serde_json::from_value(value)?;
-            for (frame, sampled) in interpolation::materialize(&track, start, end, step) {
-                out.push(MaterializedShape {
-                    track_id: track.id.clone(),
-                    label_id: track.label_id.clone(),
-                    label_name: track.label_name.clone(),
-                    color: track.color.clone(),
-                    kind: track.kind.clone(),
-                    frame,
-                    shape: sampled.shape,
-                    keyframe: sampled.keyframe,
-                    interpolated: !sampled.keyframe,
-                });
-            }
-        }
-        Ok(out)
+impl IngestReporter for TauriIngestReporter {
+    fn progress(&mut self, stage: &str, progress: f64) {
+        let stage = stage.to_string();
+        self.service.update_job(&self.app, &self.job_id, |job| {
+            job.stage = stage;
+            job.progress = progress;
+        });
+    }
+
+    fn frames_ready(&mut self, frames_dir: &Path) {
+        let _ = self
+            .app
+            .asset_protocol_scope()
+            .allow_directory(frames_dir, true);
     }
 }

--- a/apps/studio/src-tauri/src/lib.rs
+++ b/apps/studio/src-tauri/src/lib.rs
@@ -1003,9 +1003,21 @@ pub fn run() {
             let analysis_service = Arc::new(
                 crate::domain::analysis::service::AnalysisService::new(store_arc.clone()),
             );
-            let video_service = Arc::new(crate::domain::video::service::VideoService::new(
-                store_arc.clone(),
+            // Video module: persistence is a binary adapter over the residual
+            // store; the FFmpeg pipeline is the crate's infrastructure. The
+            // binary VideoService owns only the ingest job lifecycle.
+            let video_repo: Arc<dyn vailabel_video::domain::VideoRepository> = Arc::new(
+                crate::domain::video::repository::VideoStoreRepository::new(store_arc.clone()),
+            );
+            let video_pipeline: Arc<dyn vailabel_video::application::VideoPipeline> =
+                Arc::new(vailabel_video::infrastructure::FfmpegPipeline::new());
+            let video_app_service = Arc::new(vailabel_video::application::VideoAppService::new(
+                video_repo,
+                video_pipeline,
                 app_dir.join("video-frames"),
+            ));
+            let video_service = Arc::new(crate::domain::video::service::VideoService::new(
+                video_app_service,
             ));
 
             // Embedded AI Runtime. Built but NOT started here — the heavyweight


### PR DESCRIPTION
## Summary

Continues the DDD modular-monolith refactor (PR #232) by moving the **Video Annotation** business logic out of the binary's `src/domain/video` into the `vailabel-video` crate, working toward the goal of emptying `src-tauri/src/domain`. The binary keeps only the ingest job lifecycle (worker thread + the `video://progress` Tauri event + asset-protocol scope).

IPC command responses and the `video://progress` payloads are unchanged.

## What moved

**`vailabel-video` crate** (was a stub of domain types only — now fully layered):

| Layer | Contents |
|---|---|
| `domain/` | the pure `interpolation` materializer (moved in, with its 5 unit tests) + the `VideoRepository` persistence port |
| `application/` | `VideoAppService` (import/probe-merge, video & track CRUD, keyframe sort, export materialization, the ingest pipeline) + the `VideoPipeline` (FFmpeg) and `IngestReporter` (progress / asset-scope) ports — no FFmpeg/filesystem/Tauri knowledge |
| `infrastructure/` | `FfmpegPipeline` — the `ffmpeg`/`ffprobe` CLI moved behind the port (the only layer with `std::process` / `std::fs`) |

**Binary side** ([apps/studio/src-tauri](apps/studio/src-tauri)):
- [src/domain/video/service.rs](apps/studio/src-tauri/src/domain/video/service.rs) — 356 → ~210-line facade. Forwards CRUD/export to the app service; retains the job map, worker thread, `video://progress` emit, and asset-protocol scope, driving the crate through the `IngestReporter` port.
- [src/domain/video/repository.rs](apps/studio/src-tauri/src/domain/video/repository.rs) — new `VideoStoreRepository` adapter implementing the crate's port over the residual `DesktopStore`. The `videos`/`tracks` JSON-blob tables stay in the store, so this is a **logic-only** move with no schema surgery.
- `ffmpeg.rs` and `interpolation.rs` deleted from the binary (moved into the crate).
- [dependency_rules.rs](apps/studio/src-tauri/crates/arch-tests/tests/dependency_rules.rs) — `video` moves from `FULLY_PURE` to `LAYERED` (its infrastructure is the FFmpeg CLI); the pure layers stay enforced.

## Verification (all green)
- `cargo test -p vailabel-video` → 5 passed (the moved interpolation tests)
- `cargo test -p vailabel-arch-tests` → 4 passed (pure layers clean; `video` correctly LAYERED)
- `cargo check` (binary, default `yolo-inference`) → clean, no warnings

## Notes
- Surfaced error strings carry the standard `DomainError` Display prefix (`repository error:` / `validation error:`), consistent with the other migrated modules.
- This is one module of the remaining `src/domain` work. Still to migrate: `analysis`, the large `ai`/copilot service, and `runtime`; then the final step of relocating the per-module command/facade glue and removing the `domain/` folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
