### PR TITLE
refactor(ddd): empty src/domain — analysis migration + ai slice 1

### DIFF
--- a/apps/studio/src-tauri/crates/analysis/Cargo.toml
+++ b/apps/studio/src-tauri/crates/analysis/Cargo.toml
@@ -2,11 +2,16 @@
 name = "vailabel-analysis"
 version = "0.1.0"
 edition = "2021"
-description = "Dataset Intelligence module: the analysis report model (health, analytics, quality, image-quality, outliers, findings) and request DTOs. A dataset-statistics/health concern; pure domain types."
+description = "Dataset Intelligence module: the analysis report model (health, analytics, quality, image-quality, outliers, findings), the pure metadata/outlier engine, and the analysis use cases. Domain/application/contracts are pure; image-pixel decoding lives behind the ImageDecoder port in infrastructure."
 
 [lib]
 name = "vailabel_analysis"
 
 [dependencies]
 vailabel-core = { workspace = true }
+vailabel-shared = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
+# Infrastructure layer only: decode image pixels for the blur/exposure/embedding
+# metrics, behind the `ImageDecoder` port.
+image = { version = "0.25", default-features = false, features = ["jpeg", "png", "gif"] }

--- a/apps/studio/src-tauri/crates/analysis/src/application/mod.rs
+++ b/apps/studio/src-tauri/crates/analysis/src/application/mod.rs
@@ -1,0 +1,9 @@
+//! The analysis application layer: the use-case service plus the ports it
+//! orchestrates (the image-pixel decoder and the progress reporter), injected by
+//! the composition root. No `image`/filesystem/Tauri knowledge.
+
+pub mod ports;
+pub mod service;
+
+pub use ports::{AnalysisReporter, ImageDecoder};
+pub use service::AnalysisAppService;

--- a/apps/studio/src-tauri/crates/analysis/src/application/ports.rs
+++ b/apps/studio/src-tauri/crates/analysis/src/application/ports.rs
@@ -1,0 +1,38 @@
+//! Ports the analysis use case depends on. The composition root implements the
+//! decoder over the `image` crate and the reporter over the Tauri event channel;
+//! the application layer stays unaware of both.
+
+use crate::domain::engine::PixelOutcome;
+use crate::domain::AnalysisConfig;
+
+/// Decode one image's pixels into quality/embedding metrics. The infrastructure
+/// implementation reads the file; the use case never sees `image` or `std::fs`.
+pub trait ImageDecoder: Send + Sync {
+    fn analyze_pixels(
+        &self,
+        image_id: &str,
+        name: &str,
+        path: &str,
+        cfg: &AnalysisConfig,
+    ) -> PixelOutcome;
+}
+
+/// Receives analysis progress so the binary can stream it over
+/// `analysis://progress`. The methods mark the run's phases (the binary applies
+/// the exact job-state mutations + emits). Implemented at the composition root.
+pub trait AnalysisReporter {
+    /// Dataset load has begun.
+    fn loading_dataset(&mut self);
+
+    /// The metadata pass is starting; `total` images will be processed.
+    fn analyzing_metadata(&mut self, total: usize);
+
+    /// Pixel-pass progress: `processed` of `total` images decoded.
+    fn analyzing_images(&mut self, processed: usize, total: usize);
+
+    /// The embedding-outlier pass is starting.
+    fn detecting_outliers(&mut self);
+
+    /// The finished report is being persisted.
+    fn saving_report(&mut self);
+}

--- a/apps/studio/src-tauri/crates/analysis/src/application/service.rs
+++ b/apps/studio/src-tauri/crates/analysis/src/application/service.rs
@@ -1,0 +1,122 @@
+//! The Dataset Intelligence use-case service.
+
+use std::sync::Arc;
+
+use serde_json::Value;
+use vailabel_core::DomainResult;
+
+use crate::application::ports::{AnalysisReporter, ImageDecoder};
+use crate::contracts::AnalysisRequest;
+use crate::domain::engine::{self, PixelOutcome};
+use crate::domain::{AnalysisRepository, ImageQualityReport, ImageRef};
+
+/// Emit a progress event at most every this many processed images.
+const PROGRESS_EVERY: usize = 25;
+
+/// Application service for Dataset Intelligence.
+///
+/// Orchestrates the persistence ([`AnalysisRepository`]) and pixel-decode
+/// ([`ImageDecoder`]) ports injected by the composition root. The background job
+/// lifecycle (threads + the `analysis://progress` event) lives in the binary,
+/// which drives [`AnalysisAppService::run`] through an [`AnalysisReporter`].
+pub struct AnalysisAppService {
+    repo: Arc<dyn AnalysisRepository>,
+    decoder: Arc<dyn ImageDecoder>,
+}
+
+impl AnalysisAppService {
+    pub fn new(repo: Arc<dyn AnalysisRepository>, decoder: Arc<dyn ImageDecoder>) -> Self {
+        Self { repo, decoder }
+    }
+
+    /// Run a full analysis (metadata pass + optional pixel pass + outliers +
+    /// assemble + persist), reporting progress through `reporter`. Returns the
+    /// persisted report id.
+    pub fn run(
+        &self,
+        request: &AnalysisRequest,
+        reporter: &mut dyn AnalysisReporter,
+    ) -> DomainResult<String> {
+        let cfg = &request.config;
+        let project_id = &request.project_id;
+
+        reporter.loading_dataset();
+        let images = self.repo.list_images(project_id)?;
+        let annotations = self.repo.list_annotations(project_id)?;
+        let labels = self.repo.list_labels(project_id)?;
+
+        reporter.analyzing_metadata(images.len());
+        let metadata = engine::analyze_metadata(&images, &annotations, &labels, cfg);
+
+        // ── Pixel pass (optional, slow) ─────────────────────────────────────
+        let mut image_quality = ImageQualityReport::default();
+        let mut corrupted_images: Vec<ImageRef> = Vec::new();
+        let mut metrics = Vec::new();
+
+        if cfg.include_image_quality {
+            let total = images.len();
+            for (index, image) in images.iter().enumerate() {
+                let id = image.get("id").and_then(Value::as_str).unwrap_or_default();
+                let name = image
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or("Untitled");
+                let path = image.get("path").and_then(Value::as_str).unwrap_or_default();
+
+                match self.decoder.analyze_pixels(id, name, path, cfg) {
+                    PixelOutcome::Metrics(metric) => {
+                        engine::classify_image_quality(&metric, cfg, &mut image_quality);
+                        metrics.push(*metric);
+                        image_quality.analyzed += 1;
+                    }
+                    PixelOutcome::Corrupted(reason) => {
+                        corrupted_images.push(ImageRef {
+                            image_id: id.to_string(),
+                            name: name.to_string(),
+                            reason: Some(reason),
+                        });
+                    }
+                    PixelOutcome::Unsupported => {
+                        image_quality.skipped += 1;
+                    }
+                }
+
+                if index % PROGRESS_EVERY == 0 || index + 1 == total {
+                    reporter.analyzing_images(index + 1, total);
+                }
+            }
+        } else {
+            image_quality.skipped = images.len();
+        }
+
+        reporter.detecting_outliers();
+        let embedding_outliers = engine::embedding_outliers(&metrics, cfg.outlier_z_threshold);
+
+        reporter.saving_report();
+        let report = engine::build_report(
+            project_id,
+            metadata,
+            image_quality,
+            corrupted_images,
+            embedding_outliers,
+        );
+        self.repo.upsert_report(&report)?;
+        Ok(report.id)
+    }
+
+    pub fn list_reports(&self, project_id: &str) -> DomainResult<Vec<Value>> {
+        self.repo.list_reports(project_id)
+    }
+
+    pub fn get_report(&self, id: &str) -> DomainResult<Option<Value>> {
+        self.repo.get_report(id)
+    }
+
+    pub fn latest_report(&self, project_id: &str) -> DomainResult<Option<Value>> {
+        self.repo.latest_report(project_id)
+    }
+
+    pub fn delete_report(&self, id: &str) -> DomainResult<()> {
+        self.repo.delete_report(id)
+    }
+}

--- a/apps/studio/src-tauri/crates/analysis/src/domain/engine.rs
+++ b/apps/studio/src-tauri/crates/analysis/src/domain/engine.rs
@@ -1,25 +1,23 @@
-//! The analysis engine — pure computation over dataset metadata and image
-//! pixels. Nothing here touches the database, Tauri, or threads, so each
-//! function is independently testable and cheap to reason about.
+//! The analysis engine — pure computation over dataset metadata and decoded
+//! image metrics. Nothing here touches the database, the filesystem, Tauri, or
+//! threads, so each function is independently testable.
 //!
-//! Two passes:
-//!   * [`analyze_metadata`] works off the JSON rows already in SQLite (images,
-//!     annotations, labels). Fast, no disk I/O.
-//!   * [`analyze_pixels`] decodes a single image to derive blur/exposure/
-//!     embedding features. Slow; the service runs it on a worker thread and
-//!     reports progress.
+//! - [`analyze_metadata`] works off the JSON rows (images/annotations/labels).
+//! - [`embedding_outliers`] flags images far from the dataset feature centroid.
+//! - the report-assembly helpers ([`build_report`], [`collect_findings`],
+//!   [`health_summary`], [`classify_image_quality`]) fold the metadata pass and
+//!   the (infrastructure-provided) pixel pass into the final [`AnalysisReport`].
+//!
+//! The slow per-image pixel decode itself is the `ImageDecoder` port, lives in
+//! `infrastructure`, and yields the [`PixelMetrics`] / [`PixelOutcome`] consumed
+//! here.
 
 use std::collections::HashMap;
-use std::path::Path;
 
-use image::GenericImageView;
 use serde_json::Value;
+use vailabel_shared::{new_id, now_iso};
 
-use super::model::*;
-
-const SUPPORTED_DECODE_EXT: &[&str] = &["jpg", "jpeg", "png", "gif"];
-/// Longest edge an image is downscaled to before computing pixel metrics.
-const THUMB_EDGE: u32 = 256;
+use super::*;
 
 // ── Parsed metadata views ───────────────────────────────────────────────────
 
@@ -45,7 +43,7 @@ struct AnnMeta {
 }
 
 /// Everything the metadata pass produces. The service flattens this (plus the
-/// pixel pass) into a [`AnalysisReport`].
+/// pixel pass) into an [`AnalysisReport`].
 pub struct MetadataAnalysis {
     pub analytics: DatasetAnalytics,
     pub missing_labels: Vec<ImageRef>,
@@ -518,7 +516,7 @@ fn aspect_bucket(width: u32, height: u32) -> &'static str {
     }
 }
 
-// ── Pixel pass ──────────────────────────────────────────────────────────────
+// ── Pixel metrics (produced by the ImageDecoder port) ───────────────────────
 
 pub struct PixelMetrics {
     pub image_id: String,
@@ -537,139 +535,6 @@ pub enum PixelOutcome {
     Metrics(Box<PixelMetrics>),
     Corrupted(String),
     Unsupported,
-}
-
-pub fn analyze_pixels(image_id: &str, name: &str, path: &str, _cfg: &AnalysisConfig) -> PixelOutcome {
-    let file = Path::new(path);
-    let ext = file
-        .extension()
-        .and_then(|e| e.to_str())
-        .map(|e| e.to_lowercase())
-        .unwrap_or_default();
-
-    if path.is_empty() || !file.exists() {
-        return PixelOutcome::Corrupted("File not found".into());
-    }
-    if !SUPPORTED_DECODE_EXT.contains(&ext.as_str()) {
-        return PixelOutcome::Unsupported;
-    }
-
-    let img = match image::open(file) {
-        Ok(img) => img,
-        Err(err) => return PixelOutcome::Corrupted(format!("Decode failed: {err}")),
-    };
-    let (width, height) = img.dimensions();
-    if width == 0 || height == 0 {
-        return PixelOutcome::Corrupted("Zero-sized image".into());
-    }
-
-    let thumb = img.thumbnail(THUMB_EDGE, THUMB_EDGE);
-    let luma = thumb.to_luma8();
-    let rgb = thumb.to_rgb8();
-
-    let (brightness, contrast, clip_high, clip_low) = luma_stats(&luma);
-    let blur_score = variance_of_laplacian(&luma);
-    let (mean_r, mean_g, mean_b) = rgb_means(&rgb);
-
-    let aspect = width as f64 / height as f64;
-    let megapixels = (width as f64 * height as f64) / 1_000_000.0;
-    let features = vec![
-        mean_r,
-        mean_g,
-        mean_b,
-        brightness,
-        contrast,
-        (blur_score + 1.0).ln(),
-        aspect.ln(),
-        (megapixels + 0.001).ln(),
-    ];
-
-    PixelOutcome::Metrics(Box::new(PixelMetrics {
-        image_id: image_id.to_string(),
-        name: name.to_string(),
-        width,
-        height,
-        blur_score,
-        brightness,
-        clip_high,
-        clip_low,
-        features,
-    }))
-}
-
-/// Returns (mean brightness 0..1, contrast/stddev 0..1, clip-high frac, clip-low frac).
-fn luma_stats(luma: &image::GrayImage) -> (f64, f64, f64, f64) {
-    let pixels = luma.as_raw();
-    if pixels.is_empty() {
-        return (0.0, 0.0, 0.0, 0.0);
-    }
-    let n = pixels.len() as f64;
-    let mut sum = 0.0;
-    let mut sum_sq = 0.0;
-    let mut high = 0usize;
-    let mut low = 0usize;
-    for &p in pixels {
-        let v = p as f64;
-        sum += v;
-        sum_sq += v * v;
-        if p >= 250 {
-            high += 1;
-        }
-        if p <= 5 {
-            low += 1;
-        }
-    }
-    let mean = sum / n;
-    let variance = (sum_sq / n - mean * mean).max(0.0);
-    (
-        mean / 255.0,
-        variance.sqrt() / 255.0,
-        high as f64 / n,
-        low as f64 / n,
-    )
-}
-
-/// Variance of the Laplacian — the classic sharpness/blur metric.
-fn variance_of_laplacian(luma: &image::GrayImage) -> f64 {
-    let (w, h) = luma.dimensions();
-    if w < 3 || h < 3 {
-        return 0.0;
-    }
-    let at = |x: u32, y: u32| luma.get_pixel(x, y)[0] as f64;
-    let mut values = Vec::with_capacity(((w - 2) * (h - 2)) as usize);
-    for y in 1..h - 1 {
-        for x in 1..w - 1 {
-            let lap = at(x, y - 1)
-                + at(x - 1, y)
-                + at(x + 1, y)
-                + at(x, y + 1)
-                - 4.0 * at(x, y);
-            values.push(lap);
-        }
-    }
-    if values.is_empty() {
-        return 0.0;
-    }
-    let n = values.len() as f64;
-    let mean = values.iter().sum::<f64>() / n;
-    values.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / n
-}
-
-fn rgb_means(rgb: &image::RgbImage) -> (f64, f64, f64) {
-    let pixels = rgb.as_raw();
-    if pixels.is_empty() {
-        return (0.0, 0.0, 0.0);
-    }
-    let count = (pixels.len() / 3) as f64;
-    let mut r = 0.0;
-    let mut g = 0.0;
-    let mut b = 0.0;
-    for chunk in pixels.chunks_exact(3) {
-        r += chunk[0] as f64;
-        g += chunk[1] as f64;
-        b += chunk[2] as f64;
-    }
-    (r / count / 255.0, g / count / 255.0, b / count / 255.0)
 }
 
 /// Standardize each feature dimension (z-score) and flag images whose distance
@@ -727,6 +592,191 @@ pub fn embedding_outliers(metrics: &[PixelMetrics], z_threshold: f64) -> Vec<Out
     outliers.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
     outliers.truncate(50);
     outliers
+}
+
+// ── Report assembly ─────────────────────────────────────────────────────────
+
+/// Fold one image's [`PixelMetrics`] into the running image-quality report.
+pub fn classify_image_quality(
+    metric: &PixelMetrics,
+    cfg: &AnalysisConfig,
+    report: &mut ImageQualityReport,
+) {
+    let make_ref = |reason: String| ImageQualityRef {
+        image_id: metric.image_id.clone(),
+        name: metric.name.clone(),
+        width: metric.width,
+        height: metric.height,
+        blur_score: metric.blur_score,
+        brightness: metric.brightness,
+        reason,
+    };
+
+    if metric.blur_score < cfg.blur_threshold {
+        report
+            .blurry
+            .push(make_ref(format!("Low sharpness ({:.0})", metric.blur_score)));
+    }
+    if metric.brightness >= cfg.overexposed_threshold || metric.clip_high > 0.6 {
+        report.overexposed.push(make_ref(format!(
+            "Bright ({:.0}%, {:.0}% clipped)",
+            metric.brightness * 100.0,
+            metric.clip_high * 100.0
+        )));
+    }
+    if metric.brightness <= cfg.underexposed_threshold || metric.clip_low > 0.6 {
+        report.underexposed.push(make_ref(format!(
+            "Dark ({:.0}%, {:.0}% clipped)",
+            metric.brightness * 100.0,
+            metric.clip_low * 100.0
+        )));
+    }
+
+    let long_edge = metric.width.max(metric.height) as f64;
+    let short_edge = metric.width.min(metric.height).max(1) as f64;
+    let aspect = long_edge / short_edge;
+    if metric.width < cfg.min_resolution || metric.height < cfg.min_resolution {
+        report.low_resolution.push(make_ref(format!(
+            "Small ({}×{})",
+            metric.width, metric.height
+        )));
+    } else if aspect > cfg.max_aspect_ratio {
+        report
+            .low_resolution
+            .push(make_ref(format!("Extreme aspect ratio ({aspect:.1}:1)")));
+    }
+}
+
+/// Fold the metadata pass + pixel pass into the final persisted report.
+pub fn build_report(
+    project_id: &str,
+    metadata: MetadataAnalysis,
+    image_quality: ImageQualityReport,
+    corrupted_images: Vec<ImageRef>,
+    embedding_outliers: Vec<OutlierRef>,
+) -> AnalysisReport {
+    let MetadataAnalysis {
+        analytics,
+        missing_labels,
+        empty_annotations,
+        invalid_polygons,
+        rare_classes,
+        suspicious_labels,
+    } = metadata;
+
+    let quality = QualityValidation {
+        missing_labels,
+        empty_annotations,
+        invalid_polygons,
+        corrupted_images,
+    };
+    let outliers = OutlierReport {
+        embedding_outliers,
+        rare_classes,
+        suspicious_labels,
+    };
+
+    let findings = collect_findings(&quality, &image_quality, &outliers);
+    let health = health_summary(
+        &findings,
+        analytics.dataset_stats.total_images,
+        analytics.dataset_stats.total_annotations,
+    );
+
+    AnalysisReport {
+        id: new_id(),
+        project_id: project_id.to_string(),
+        created_at: now_iso(),
+        image_quality_analyzed: image_quality.analyzed > 0 || image_quality.skipped > 0,
+        image_count: analytics.dataset_stats.total_images,
+        annotation_count: analytics.dataset_stats.total_annotations,
+        label_count: analytics.label_distribution.len(),
+        health,
+        analytics,
+        quality,
+        image_quality,
+        outliers,
+        findings,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_findings(
+    quality: &QualityValidation,
+    image_quality: &ImageQualityReport,
+    outliers: &OutlierReport,
+) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    let mut push = |category: &str, kind: &str, severity: &str, message: String, image_id: Option<String>, annotation_id: Option<String>, metric: Option<f64>| {
+        findings.push(Finding {
+            id: new_id(),
+            category: category.into(),
+            kind: kind.into(),
+            severity: severity.into(),
+            message,
+            image_id,
+            annotation_id,
+            metric,
+        });
+    };
+
+    for item in &quality.missing_labels {
+        push("quality", "missingLabels", "warning", format!("{}: no annotations", item.name), Some(item.image_id.clone()), None, None);
+    }
+    for item in &quality.empty_annotations {
+        push("quality", "emptyAnnotation", "error", format!("{} on {}: {}", item.label, item.image_name, item.reason), Some(item.image_id.clone()), Some(item.annotation_id.clone()), None);
+    }
+    for item in &quality.invalid_polygons {
+        push("quality", "invalidPolygon", "error", format!("{} on {}: {}", item.label, item.image_name, item.reason), Some(item.image_id.clone()), Some(item.annotation_id.clone()), None);
+    }
+    for item in &quality.corrupted_images {
+        push("quality", "corruptedImage", "error", format!("{}: {}", item.name, item.reason.clone().unwrap_or_default()), Some(item.image_id.clone()), None, None);
+    }
+    for item in &image_quality.blurry {
+        push("imageQuality", "blur", "warning", format!("{}: {}", item.name, item.reason), Some(item.image_id.clone()), None, Some(item.blur_score));
+    }
+    for item in &image_quality.overexposed {
+        push("imageQuality", "overexposed", "warning", format!("{}: {}", item.name, item.reason), Some(item.image_id.clone()), None, Some(item.brightness));
+    }
+    for item in &image_quality.underexposed {
+        push("imageQuality", "underexposed", "warning", format!("{}: {}", item.name, item.reason), Some(item.image_id.clone()), None, Some(item.brightness));
+    }
+    for item in &image_quality.low_resolution {
+        push("imageQuality", "lowResolution", "warning", format!("{}: {}", item.name, item.reason), Some(item.image_id.clone()), None, None);
+    }
+    for item in &outliers.embedding_outliers {
+        push("outlier", "embeddingOutlier", "info", format!("{}: {}", item.name, item.reason), Some(item.image_id.clone()), None, Some(item.score));
+    }
+    for item in &outliers.rare_classes {
+        push("outlier", "rareClass", "info", format!("Rare class '{}' ({} annotations)", item.label, item.count), None, None, Some(item.count as f64));
+    }
+    for item in &outliers.suspicious_labels {
+        push("outlier", "suspiciousLabel", "warning", format!("{} on {}: {}", item.label, item.image_name, item.reason), Some(item.image_id.clone()), Some(item.annotation_id.clone()), None);
+    }
+
+    findings
+}
+
+fn health_summary(findings: &[Finding], image_count: usize, annotation_count: usize) -> HealthSummary {
+    let mut errors = 0;
+    let mut warnings = 0;
+    let mut infos = 0;
+    for finding in findings {
+        match finding.severity.as_str() {
+            "error" => errors += 1,
+            "warning" => warnings += 1,
+            _ => infos += 1,
+        }
+    }
+    let total_checks = (image_count + annotation_count).max(1) as f64;
+    let weighted = errors as f64 + warnings as f64 * 0.5 + infos as f64 * 0.1;
+    let score = (100.0 * (1.0 - weighted / total_checks)).clamp(0.0, 100.0);
+    HealthSummary {
+        errors,
+        warnings,
+        infos,
+        score,
+    }
 }
 
 // ── Small numeric helpers ───────────────────────────────────────────────────

--- a/apps/studio/src-tauri/crates/analysis/src/domain/mod.rs
+++ b/apps/studio/src-tauri/crates/analysis/src/domain/mod.rs
@@ -7,6 +7,11 @@
 use serde::{Deserialize, Serialize};
 use vailabel_core::Identifiable;
 
+pub mod engine;
+pub mod repository;
+
+pub use repository::AnalysisRepository;
+
 // ── Configuration ───────────────────────────────────────────────────────────
 
 /// Tunable thresholds for the analysis. All optional — the `default` fills in

--- a/apps/studio/src-tauri/crates/analysis/src/domain/repository.rs
+++ b/apps/studio/src-tauri/crates/analysis/src/domain/repository.rs
@@ -1,0 +1,37 @@
+//! The analysis persistence port.
+//!
+//! Source rows (images/annotations/labels) and persisted reports are JSON blobs;
+//! the binary implements this over its residual `DesktopStore`. Reads return the
+//! raw stored [`Value`] so the JSON crossing IPC is byte-identical.
+
+use serde_json::Value;
+use vailabel_core::DomainResult;
+
+use super::AnalysisReport;
+
+/// Read access to the dataset under analysis + persistence for finished reports.
+pub trait AnalysisRepository: Send + Sync {
+    /// The project's images (raw stored JSON).
+    fn list_images(&self, project_id: &str) -> DomainResult<Vec<Value>>;
+
+    /// The project's annotations (raw stored JSON).
+    fn list_annotations(&self, project_id: &str) -> DomainResult<Vec<Value>>;
+
+    /// The project's labels (raw stored JSON).
+    fn list_labels(&self, project_id: &str) -> DomainResult<Vec<Value>>;
+
+    /// Persist a finished report (the adapter derives + stores its summary row).
+    fn upsert_report(&self, report: &AnalysisReport) -> DomainResult<()>;
+
+    /// Compact report summaries for a project, newest first.
+    fn list_reports(&self, project_id: &str) -> DomainResult<Vec<Value>>;
+
+    /// One full report by id.
+    fn get_report(&self, id: &str) -> DomainResult<Option<Value>>;
+
+    /// The most recent full report for a project.
+    fn latest_report(&self, project_id: &str) -> DomainResult<Option<Value>>;
+
+    /// Delete a report by id.
+    fn delete_report(&self, id: &str) -> DomainResult<()>;
+}

--- a/apps/studio/src-tauri/crates/analysis/src/infrastructure/decoder.rs
+++ b/apps/studio/src-tauri/crates/analysis/src/infrastructure/decoder.rs
@@ -1,0 +1,172 @@
+//! The pixel decoder — the only place that reads image files.
+//!
+//! Decodes a single image, downsamples it, and derives blur/exposure/embedding
+//! features. Implements the [`ImageDecoder`] port so the application layer stays
+//! free of the `image` crate and filesystem access.
+
+use std::path::Path;
+
+use image::GenericImageView;
+
+use crate::application::ports::ImageDecoder;
+use crate::domain::engine::{PixelMetrics, PixelOutcome};
+use crate::domain::AnalysisConfig;
+
+const SUPPORTED_DECODE_EXT: &[&str] = &["jpg", "jpeg", "png", "gif"];
+/// Longest edge an image is downscaled to before computing pixel metrics.
+const THUMB_EDGE: u32 = 256;
+
+/// The `image`-crate implementation of the pixel-decode port.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ImageQualityDecoder;
+
+impl ImageQualityDecoder {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl ImageDecoder for ImageQualityDecoder {
+    fn analyze_pixels(
+        &self,
+        image_id: &str,
+        name: &str,
+        path: &str,
+        cfg: &AnalysisConfig,
+    ) -> PixelOutcome {
+        analyze_pixels(image_id, name, path, cfg)
+    }
+}
+
+fn analyze_pixels(image_id: &str, name: &str, path: &str, _cfg: &AnalysisConfig) -> PixelOutcome {
+    let file = Path::new(path);
+    let ext = file
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_lowercase())
+        .unwrap_or_default();
+
+    if path.is_empty() || !file.exists() {
+        return PixelOutcome::Corrupted("File not found".into());
+    }
+    if !SUPPORTED_DECODE_EXT.contains(&ext.as_str()) {
+        return PixelOutcome::Unsupported;
+    }
+
+    let img = match image::open(file) {
+        Ok(img) => img,
+        Err(err) => return PixelOutcome::Corrupted(format!("Decode failed: {err}")),
+    };
+    let (width, height) = img.dimensions();
+    if width == 0 || height == 0 {
+        return PixelOutcome::Corrupted("Zero-sized image".into());
+    }
+
+    let thumb = img.thumbnail(THUMB_EDGE, THUMB_EDGE);
+    let luma = thumb.to_luma8();
+    let rgb = thumb.to_rgb8();
+
+    let (brightness, contrast, clip_high, clip_low) = luma_stats(&luma);
+    let blur_score = variance_of_laplacian(&luma);
+    let (mean_r, mean_g, mean_b) = rgb_means(&rgb);
+
+    let aspect = width as f64 / height as f64;
+    let megapixels = (width as f64 * height as f64) / 1_000_000.0;
+    let features = vec![
+        mean_r,
+        mean_g,
+        mean_b,
+        brightness,
+        contrast,
+        (blur_score + 1.0).ln(),
+        aspect.ln(),
+        (megapixels + 0.001).ln(),
+    ];
+
+    PixelOutcome::Metrics(Box::new(PixelMetrics {
+        image_id: image_id.to_string(),
+        name: name.to_string(),
+        width,
+        height,
+        blur_score,
+        brightness,
+        clip_high,
+        clip_low,
+        features,
+    }))
+}
+
+/// Returns (mean brightness 0..1, contrast/stddev 0..1, clip-high frac, clip-low frac).
+fn luma_stats(luma: &image::GrayImage) -> (f64, f64, f64, f64) {
+    let pixels = luma.as_raw();
+    if pixels.is_empty() {
+        return (0.0, 0.0, 0.0, 0.0);
+    }
+    let n = pixels.len() as f64;
+    let mut sum = 0.0;
+    let mut sum_sq = 0.0;
+    let mut high = 0usize;
+    let mut low = 0usize;
+    for &p in pixels {
+        let v = p as f64;
+        sum += v;
+        sum_sq += v * v;
+        if p >= 250 {
+            high += 1;
+        }
+        if p <= 5 {
+            low += 1;
+        }
+    }
+    let mean = sum / n;
+    let variance = (sum_sq / n - mean * mean).max(0.0);
+    (
+        mean / 255.0,
+        variance.sqrt() / 255.0,
+        high as f64 / n,
+        low as f64 / n,
+    )
+}
+
+/// Variance of the Laplacian — the classic sharpness/blur metric.
+fn variance_of_laplacian(luma: &image::GrayImage) -> f64 {
+    let (w, h) = luma.dimensions();
+    if w < 3 || h < 3 {
+        return 0.0;
+    }
+    let at = |x: u32, y: u32| luma.get_pixel(x, y)[0] as f64;
+    let mut values = Vec::with_capacity(((w - 2) * (h - 2)) as usize);
+    for y in 1..h - 1 {
+        for x in 1..w - 1 {
+            let lap = at(x, y - 1)
+                + at(x - 1, y)
+                + at(x + 1, y)
+                + at(x, y + 1)
+                - 4.0 * at(x, y);
+            values.push(lap);
+        }
+    }
+    if values.is_empty() {
+        return 0.0;
+    }
+    let n = values.len() as f64;
+    let mean = values.iter().sum::<f64>() / n;
+    values.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / n
+}
+
+fn rgb_means(rgb: &image::RgbImage) -> (f64, f64, f64) {
+    let pixels = rgb.as_raw();
+    if pixels.is_empty() {
+        return (0.0, 0.0, 0.0);
+    }
+    let count = (pixels.len() / 3) as f64;
+    let mut r = 0.0;
+    let mut g = 0.0;
+    let mut b = 0.0;
+    for chunk in pixels.chunks_exact(3) {
+        r += chunk[0] as f64;
+        g += chunk[1] as f64;
+        b += chunk[2] as f64;
+    }
+    (r / count / 255.0, g / count / 255.0, b / count / 255.0)
+}

--- a/apps/studio/src-tauri/crates/analysis/src/infrastructure/mod.rs
+++ b/apps/studio/src-tauri/crates/analysis/src/infrastructure/mod.rs
@@ -1,0 +1,7 @@
+//! The infrastructure layer: the `image`-crate pixel decoder implementing the
+//! [`crate::application::ImageDecoder`] port. The only layer that reads image
+//! files.
+
+pub mod decoder;
+
+pub use decoder::ImageQualityDecoder;

--- a/apps/studio/src-tauri/crates/analysis/src/lib.rs
+++ b/apps/studio/src-tauri/crates/analysis/src/lib.rs
@@ -2,9 +2,16 @@
 //!
 //! The analysis report model (dataset health, analytics, quality validation,
 //! image-quality, outliers, and the unified findings list) plus the request
-//! DTOs. Conceptually this is a *dataset statistics/health* concern; it is kept
-//! as its own module crate for Phase 1 (1:1 with the existing `domain/analysis`).
-//! Pure domain types — the analysis engine/service stay in the binary.
+//! DTOs. Conceptually this is a *dataset statistics/health* concern, layered
+//! like the other module crates: `domain` holds the report model + the pure
+//! `engine` (metadata analysis, geometry, outlier stats, report assembly) + the
+//! `AnalysisRepository` port; `application` holds the `AnalysisAppService` use
+//! cases + the `ImageDecoder` (pixel pass) and `AnalysisReporter` (progress)
+//! ports; `infrastructure` holds the `image`-crate pixel decoder (the only layer
+//! that reads image files). The background job lifecycle (threads + the
+//! `analysis://progress` Tauri event) stays in the binary.
 
+pub mod application;
 pub mod contracts;
 pub mod domain;
+pub mod infrastructure;

--- a/apps/studio/src-tauri/crates/arch-tests/tests/dependency_rules.rs
+++ b/apps/studio/src-tauri/crates/arch-tests/tests/dependency_rules.rs
@@ -16,16 +16,19 @@ use std::path::{Path, PathBuf};
 
 /// Crates whose ENTIRE `src/` must be infrastructure-free.
 const FULLY_PURE: &[&str] = &[
-    "core", "shared", "plugin", "analysis", "models", "copilot", "search",
+    "core", "shared", "plugin", "models", "copilot", "search",
 ];
 
 /// Module crates that own an `infrastructure/` layer (typed Diesel; for `cloud`
-/// an OpenDAL object store; for `video` the FFmpeg CLI). Their
-/// `domain`/`application`/`contracts` layers must stay pure; `infrastructure/`
-/// legitimately depends on its backing technology (diesel + `vailabel-db`,
-/// opendal + `std::fs`, or `std::process` + `std::fs`), so it is scanned at
-/// folder granularity and its `Cargo.toml` is exempt from the dependency check.
-const LAYERED: &[&str] = &["project", "dataset", "annotation", "training", "cloud", "video"];
+/// an OpenDAL object store; for `video` the FFmpeg CLI; for `analysis` the
+/// `image`-crate pixel decoder). Their `domain`/`application`/`contracts` layers
+/// must stay pure; `infrastructure/` legitimately depends on its backing
+/// technology (diesel + `vailabel-db`, opendal, the FFmpeg CLI, or `image` +
+/// filesystem reads), so it is scanned at folder granularity and its
+/// `Cargo.toml` is exempt from the dependency check.
+const LAYERED: &[&str] = &[
+    "project", "dataset", "annotation", "training", "cloud", "video", "analysis",
+];
 
 /// The layers of a LAYERED crate that must remain pure.
 const PURE_LAYERS: &[&str] = &["domain", "application", "contracts"];
@@ -101,6 +104,27 @@ fn dependencies_block(manifest: &str) -> String {
     rest[..end].to_string()
 }
 
+/// True if `code` uses `token` as a real path segment — i.e. `token` appears at
+/// least once NOT immediately preceded by an identifier character. This rejects
+/// substring false-positives where the token is the tail of a larger identifier
+/// (`ImageQualityReport::` / `export::` / `sort::` matching `ort::`) while still
+/// catching `use ort::`, `crate::ort::`, `tauri::`, `std::fs`, etc. (the
+/// trailing `::` / `std::` shape is already baked into each token).
+fn uses_token(code: &str, token: &str) -> bool {
+    let bytes = code.as_bytes();
+    let mut start = 0;
+    while let Some(pos) = code[start..].find(token) {
+        let idx = start + pos;
+        let preceded_by_ident =
+            idx > 0 && (bytes[idx - 1] == b'_' || bytes[idx - 1].is_ascii_alphanumeric());
+        if !preceded_by_ident {
+            return true;
+        }
+        start = idx + 1;
+    }
+    false
+}
+
 /// Scan every `.rs` file under `dir` for forbidden usages, recording any in
 /// `violations`. Returns the number of files scanned.
 fn scan_dir(dir: &Path, violations: &mut Vec<String>) -> usize {
@@ -110,7 +134,7 @@ fn scan_dir(dir: &Path, violations: &mut Vec<String>) -> usize {
     for file in files {
         let code = strip_line_comments(&fs::read_to_string(&file).expect("read source"));
         for token in FORBIDDEN_USAGES {
-            if code.contains(token) {
+            if uses_token(&code, token) {
                 violations.push(format!("{} uses forbidden `{}`", file.display(), token));
             }
         }
@@ -159,6 +183,14 @@ fn scanner_matches_real_usage_and_ignores_comments() {
     assert!(!strip_line_comments("let report = export_thing();").contains("ort::"));
     // `std::fmt` must NOT match the forbidden `std::fs` token.
     assert!(!strip_line_comments("use std::fmt::Debug;").contains("std::fs"));
+
+    // `uses_token` rejects a token that is only the tail of a larger identifier
+    // (`Report::`/`export::`/`sort::` → `ort::`) but still catches real paths.
+    assert!(!uses_token("let x = ImageQualityReport::default();", "ort::"));
+    assert!(!uses_token("values.sort_by(|a, b| a.cmp(b));", "ort::"));
+    assert!(uses_token("use ort::Session;", "ort::"));
+    assert!(uses_token("crate::ort::init();", "ort::"));
+    assert!(uses_token("    tauri::command", "tauri::"));
 }
 
 #[test]

--- a/apps/studio/src-tauri/crates/models/Cargo.toml
+++ b/apps/studio/src-tauri/crates/models/Cargo.toml
@@ -9,3 +9,4 @@ name = "vailabel_models"
 
 [dependencies]
 serde = { workspace = true }
+serde_json = { workspace = true }

--- a/apps/studio/src-tauri/crates/models/src/domain/class_names.rs
+++ b/apps/studio/src-tauri/crates/models/src/domain/class_names.rs
@@ -1,0 +1,202 @@
+//! Resolving a model's class labels — from a parsed config blob (array, nested
+//! object, or numeric-keyed map) or a built-in family table. Pure.
+
+use serde_json::{Map, Value};
+
+const COCO_80_CLASS_NAMES: &[&str] = &[
+    "person",
+    "bicycle",
+    "car",
+    "motorcycle",
+    "airplane",
+    "bus",
+    "train",
+    "truck",
+    "boat",
+    "traffic light",
+    "fire hydrant",
+    "stop sign",
+    "parking meter",
+    "bench",
+    "bird",
+    "cat",
+    "dog",
+    "horse",
+    "sheep",
+    "cow",
+    "elephant",
+    "bear",
+    "zebra",
+    "giraffe",
+    "backpack",
+    "umbrella",
+    "handbag",
+    "tie",
+    "suitcase",
+    "frisbee",
+    "skis",
+    "snowboard",
+    "sports ball",
+    "kite",
+    "baseball bat",
+    "baseball glove",
+    "skateboard",
+    "surfboard",
+    "tennis racket",
+    "bottle",
+    "wine glass",
+    "cup",
+    "fork",
+    "knife",
+    "spoon",
+    "bowl",
+    "banana",
+    "apple",
+    "sandwich",
+    "orange",
+    "broccoli",
+    "carrot",
+    "hot dog",
+    "pizza",
+    "donut",
+    "cake",
+    "chair",
+    "couch",
+    "potted plant",
+    "bed",
+    "dining table",
+    "toilet",
+    "tv",
+    "laptop",
+    "mouse",
+    "remote",
+    "keyboard",
+    "cell phone",
+    "microwave",
+    "oven",
+    "toaster",
+    "sink",
+    "refrigerator",
+    "book",
+    "clock",
+    "vase",
+    "scissors",
+    "teddy bear",
+    "hair drier",
+    "toothbrush",
+];
+
+/// Trim + drop blanks; `None` when nothing usable remains.
+pub fn normalize_class_names(names: Vec<String>) -> Option<Vec<String>> {
+    let normalized = names
+        .into_iter()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>();
+
+    if normalized.is_empty() {
+        None
+    } else {
+        Some(normalized)
+    }
+}
+
+/// Class names from a JSON array of strings or `{ "name": ... }` objects.
+pub fn extract_named_value_list(entries: &[Value]) -> Option<Vec<String>> {
+    let values = entries
+        .iter()
+        .map(|value| {
+            value.as_str().map(ToString::to_string).or_else(|| {
+                value
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+            })
+        })
+        .collect::<Option<Vec<String>>>()?;
+
+    normalize_class_names(values)
+}
+
+/// Class names from a numeric-keyed map (`{ "0": "person", "1": "car" }`),
+/// ordered by key.
+pub fn extract_named_value_map(entries: &Map<String, Value>) -> Option<Vec<String>> {
+    let mut numbered_entries = entries
+        .iter()
+        .filter_map(|(key, value)| Some((key.parse::<usize>().ok()?, value.as_str()?)))
+        .collect::<Vec<_>>();
+    numbered_entries.sort_by_key(|(index, _)| *index);
+
+    if numbered_entries.is_empty() {
+        return None;
+    }
+
+    normalize_class_names(
+        numbered_entries
+            .into_iter()
+            .map(|(_, value)| value.to_string())
+            .collect(),
+    )
+}
+
+/// Recursively pull class names from a parsed config value, probing the common
+/// keys (`classNames`/`names`/`labels`/…) before falling back to a numeric map.
+pub fn extract_class_names_from_value(value: &Value) -> Option<Vec<String>> {
+    match value {
+        Value::Array(entries) => extract_named_value_list(entries),
+        Value::Object(entries) => {
+            for key in ["classNames", "class_names", "names", "labels", "classes"] {
+                if let Some(candidate) = entries.get(key).and_then(extract_class_names_from_value) {
+                    return Some(candidate);
+                }
+            }
+            extract_named_value_map(entries)
+        }
+        _ => None,
+    }
+}
+
+/// Built-in labels for known families (COCO-80 for YOLO detection), or `None`.
+pub fn builtin_class_names(family: &str, category: &str) -> Option<Vec<String>> {
+    if category.eq_ignore_ascii_case("detection")
+        && matches!(
+            family.trim().to_ascii_lowercase().as_str(),
+            "yolo26" | "yolo11" | "yolov8"
+        )
+    {
+        return Some(
+            COCO_80_CLASS_NAMES
+                .iter()
+                .map(|value| value.to_string())
+                .collect(),
+        );
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn extracts_from_array_object_and_numeric_map() {
+        assert_eq!(
+            extract_class_names_from_value(&json!(["car", " ", "dog"])),
+            Some(vec!["car".into(), "dog".into()])
+        );
+        assert_eq!(
+            extract_class_names_from_value(&json!({ "names": { "1": "b", "0": "a" } })),
+            Some(vec!["a".into(), "b".into()])
+        );
+        assert_eq!(extract_class_names_from_value(&json!({})), None);
+    }
+
+    #[test]
+    fn builtin_only_for_known_detection_families() {
+        assert_eq!(builtin_class_names("yolo26", "detection").map(|c| c.len()), Some(80));
+        assert_eq!(builtin_class_names("yolo26", "segmentation"), None);
+        assert_eq!(builtin_class_names("random", "detection"), None);
+    }
+}

--- a/apps/studio/src-tauri/crates/models/src/domain/identity.rs
+++ b/apps/studio/src-tauri/crates/models/src/domain/identity.rs
@@ -1,0 +1,196 @@
+//! Inferring a model's identity from its name + file path: extension/runtime,
+//! Ultralytics family/variant/task, default registry rank, and the display
+//! version string. Pure (string + `std::path` logic only).
+
+use std::path::Path;
+
+/// Lowercased file extension (no dot), or empty.
+pub fn model_extension(model_path: &Path) -> String {
+    model_path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+}
+
+/// A PyTorch checkpoint (`.pt`/`.pth`) — needs ONNX export before local inference.
+pub fn is_pytorch_checkpoint(model_path: &Path) -> bool {
+    matches!(model_extension(model_path).as_str(), "pt" | "pth")
+}
+
+/// Ultralytics-style filename suffix → task, authoritative over the installed
+/// category (a `-cls`/`-seg`/`-pose` asset is that task even if it was downloaded
+/// under a "detection" catalog entry). Returns `None` for plain detectors.
+pub fn task_suffix(model_path: &Path) -> Option<&'static str> {
+    let name = model_path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_lowercase();
+    if name.contains("-cls") || name.contains("_cls") {
+        Some("classification")
+    } else if name.contains("-pose") || name.contains("_pose") {
+        Some("pose")
+    } else if name.contains("-seg") || name.contains("_seg") {
+        Some("segmentation")
+    } else {
+        None
+    }
+}
+
+/// Accurate, role-aware reason a model can't run the box detector — segmentation
+/// models are usable (via the copilot), classification/pose are different tasks.
+pub fn non_detection_reason(task: &str) -> String {
+    match task {
+        "segmentation" => "Segmentation model \u{2014} used by the AI Copilot for click/box \u{2192} polygon (ask it to \u{201c}outline them\u{201d}), not the Detect button.",
+        "classification" => "Classification model \u{2014} it labels the whole image, not regions. Install a detection model (e.g. YOLO26 Detection) to draw boxes.",
+        "pose" => "Pose-estimation model \u{2014} not a box detector. Install a detection model for AI detect.",
+        _ => "AI detect supports object-detection models; this model uses a different task.",
+    }
+    .to_string()
+}
+
+/// Best-effort `(family, variant)` from a model's name + filename
+/// (e.g. "YOLO26n" → `("yolo26", "n")`).
+pub fn infer_model_family_and_variant(name: &str, model_path: &Path) -> (String, String) {
+    let haystack = format!(
+        "{} {}",
+        name.to_ascii_lowercase(),
+        model_path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+    );
+
+    let family = if haystack.contains("yoloe-26") {
+        "yoloe-26"
+    } else if haystack.contains("yolo26") {
+        "yolo26"
+    } else if haystack.contains("yolo11") {
+        "yolo11"
+    } else if haystack.contains("yolov8") {
+        "yolov8"
+    } else {
+        ""
+    };
+
+    let variant = ["n", "s", "m", "l", "x"]
+        .iter()
+        .copied()
+        .find(|variant| {
+            haystack.contains(&format!("yolo26{variant}"))
+                || haystack.contains(&format!("yoloe-26{variant}"))
+        })
+        .unwrap_or_default();
+
+    (family.to_string(), variant.to_string())
+}
+
+/// Default sort rank for a model in the registry (lower = preferred).
+pub fn infer_default_rank(family: &str, category: &str, variant: &str) -> i64 {
+    if family == "yolo26" && category == "detection" {
+        match variant {
+            "n" => 0,
+            "s" => 10,
+            "m" => 20,
+            "l" => 30,
+            "x" => 40,
+            _ => 100,
+        }
+    } else if family == "yolo26" {
+        50
+    } else if family == "yoloe-26" {
+        100
+    } else {
+        999
+    }
+}
+
+/// `(format, runtime)` for a model file by extension.
+pub fn infer_model_runtime(model_path: &Path) -> (&'static str, &'static str) {
+    match model_extension(model_path).as_str() {
+        "onnx" => ("onnx", "ort"),
+        "pt" | "pth" => ("pytorch", "cpu"),
+        "tflite" => ("tflite", "cpu"),
+        "h5" => ("keras", "cpu"),
+        "pb" => ("tensorflow", "cpu"),
+        _ => ("unknown", "cpu"),
+    }
+}
+
+/// The canonical task-type tag for a category.
+pub fn task_type_for_category(category: &str) -> &'static str {
+    match category {
+        "segmentation" => "segmentation",
+        "classification" => "classification",
+        "pose" => "pose_estimation",
+        "tracking" => "tracking",
+        _ => "object_detection",
+    }
+}
+
+/// Display version string for an installed model (family-aware, else `name version`).
+pub fn build_model_version(
+    name: &str,
+    version: &str,
+    family: &str,
+    variant: &str,
+    category: &str,
+) -> String {
+    if !family.is_empty() && !variant.is_empty() {
+        let base = if family == "yoloe-26" {
+            format!("YOLOE-26{variant}")
+        } else {
+            format!("YOLO26{variant}")
+        };
+
+        return match category {
+            "segmentation" => format!("{base}-seg"),
+            "pose" => format!("{base}-pose"),
+            _ => base,
+        };
+    }
+    format!("{name} {version}")
+}
+
+/// Singular/plural-tolerant equality for two already-lowercased class tokens.
+pub fn class_token_matches(a: &str, b: &str) -> bool {
+    if a.is_empty() || b.is_empty() {
+        return false;
+    }
+    a == b || format!("{a}s") == b || format!("{b}s") == a
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn infers_family_variant_and_runtime() {
+        let (family, variant) = infer_model_family_and_variant("YOLO26n", Path::new("yolo26n.onnx"));
+        assert_eq!((family.as_str(), variant.as_str()), ("yolo26", "n"));
+        assert_eq!(infer_model_runtime(Path::new("m.onnx")), ("onnx", "ort"));
+        assert_eq!(infer_default_rank("yolo26", "detection", "n"), 0);
+    }
+
+    #[test]
+    fn task_suffix_overrides_category() {
+        assert_eq!(task_suffix(Path::new("yolo11n-seg.onnx")), Some("segmentation"));
+        assert_eq!(task_suffix(Path::new("yolo11n.onnx")), None);
+    }
+
+    #[test]
+    fn class_tokens_are_plural_tolerant() {
+        assert!(class_token_matches("car", "cars"));
+        assert!(class_token_matches("cats", "cat"));
+        assert!(!class_token_matches("car", "dog"));
+    }
+
+    #[test]
+    fn version_string_is_family_aware() {
+        assert_eq!(build_model_version("x", "1", "yolo26", "n", "segmentation"), "YOLO26n-seg");
+        assert_eq!(build_model_version("Custom", "2.0", "", "", "detection"), "Custom 2.0");
+    }
+}

--- a/apps/studio/src-tauri/crates/models/src/domain/mod.rs
+++ b/apps/studio/src-tauri/crates/models/src/domain/mod.rs
@@ -1,0 +1,23 @@
+//! Pure model-domain logic, extracted from the binary's `AiService`.
+//!
+//! - [`class_names`] — resolving a model's class labels from a config blob or a
+//!   built-in family table.
+//! - [`identity`] — inferring a model's family/variant/rank/runtime and its
+//!   registry version string from its name + file path.
+//!
+//! All pure: depends only on `serde_json` + `std::path`. No filesystem, ONNX,
+//! HTTP, or feature gates (the feature-gated `prediction_unsupported_reason`
+//! stays in the binary and calls these).
+
+pub mod class_names;
+pub mod identity;
+
+pub use class_names::{
+    builtin_class_names, extract_class_names_from_value, extract_named_value_list,
+    extract_named_value_map, normalize_class_names,
+};
+pub use identity::{
+    build_model_version, class_token_matches, infer_default_rank, infer_model_family_and_variant,
+    infer_model_runtime, is_pytorch_checkpoint, model_extension, non_detection_reason, task_suffix,
+    task_type_for_category,
+};

--- a/apps/studio/src-tauri/crates/models/src/lib.rs
+++ b/apps/studio/src-tauri/crates/models/src/lib.rs
@@ -5,5 +5,10 @@
 //! payloads) into [`contracts`]; the `ModelArtifact`/`ModelVersion` aggregates,
 //! the model registry, and the install/inference service logic remain in the
 //! binary (they are coupled to HTTP/filesystem/ONNX) and migrate in later phases.
+//!
+//! [`domain`] holds the first slice of that pure logic — model-identity
+//! inference (family/variant/rank/runtime, registry version string) and
+//! class-name resolution — extracted from the binary's `AiService`. No I/O.
 
 pub mod contracts;
+pub mod domain;

--- a/apps/studio/src-tauri/src/domain/ai/service.rs
+++ b/apps/studio/src-tauri/src/domain/ai/service.rs
@@ -10,7 +10,7 @@ use crate::{
     now_iso, value_string, AppError,
 };
 use reqwest::blocking::Client;
-use serde_json::{json, Map, Value};
+use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::fs;
 use std::io::copy;
@@ -20,92 +20,14 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tauri::Manager;
 use uuid::Uuid;
+use vailabel_models::domain::{
+    build_model_version, builtin_class_names, class_token_matches, extract_class_names_from_value,
+    infer_default_rank, infer_model_family_and_variant, infer_model_runtime, is_pytorch_checkpoint,
+    model_extension, non_detection_reason, task_suffix, task_type_for_category,
+};
 
 const APP_NAME: &str = "Vailabel Studio";
 const DEFAULT_AI_LABEL_COLOR: &str = "#22c55e";
-
-const COCO_80_CLASS_NAMES: &[&str] = &[
-    "person",
-    "bicycle",
-    "car",
-    "motorcycle",
-    "airplane",
-    "bus",
-    "train",
-    "truck",
-    "boat",
-    "traffic light",
-    "fire hydrant",
-    "stop sign",
-    "parking meter",
-    "bench",
-    "bird",
-    "cat",
-    "dog",
-    "horse",
-    "sheep",
-    "cow",
-    "elephant",
-    "bear",
-    "zebra",
-    "giraffe",
-    "backpack",
-    "umbrella",
-    "handbag",
-    "tie",
-    "suitcase",
-    "frisbee",
-    "skis",
-    "snowboard",
-    "sports ball",
-    "kite",
-    "baseball bat",
-    "baseball glove",
-    "skateboard",
-    "surfboard",
-    "tennis racket",
-    "bottle",
-    "wine glass",
-    "cup",
-    "fork",
-    "knife",
-    "spoon",
-    "bowl",
-    "banana",
-    "apple",
-    "sandwich",
-    "orange",
-    "broccoli",
-    "carrot",
-    "hot dog",
-    "pizza",
-    "donut",
-    "cake",
-    "chair",
-    "couch",
-    "potted plant",
-    "bed",
-    "dining table",
-    "toilet",
-    "tv",
-    "laptop",
-    "mouse",
-    "remote",
-    "keyboard",
-    "cell phone",
-    "microwave",
-    "oven",
-    "toaster",
-    "sink",
-    "refrigerator",
-    "book",
-    "clock",
-    "vase",
-    "scissors",
-    "teddy bear",
-    "hair drier",
-    "toothbrush",
-];
 
 /// One loaded inference engine, keyed by model id in [`AiService::engine_cache`].
 /// Holding distinct engines side by side lets a detect→segment turn keep both the
@@ -1054,70 +976,6 @@ struct ResolvedPredictionLabel {
     label_color: Option<String>,
 }
 
-fn normalize_class_names(names: Vec<String>) -> Option<Vec<String>> {
-    let normalized = names
-        .into_iter()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
-        .collect::<Vec<_>>();
-
-    if normalized.is_empty() {
-        None
-    } else {
-        Some(normalized)
-    }
-}
-
-fn extract_named_value_list(entries: &[Value]) -> Option<Vec<String>> {
-    let values = entries
-        .iter()
-        .map(|value| {
-            value.as_str().map(ToString::to_string).or_else(|| {
-                value
-                    .get("name")
-                    .and_then(Value::as_str)
-                    .map(ToString::to_string)
-            })
-        })
-        .collect::<Option<Vec<String>>>()?;
-
-    normalize_class_names(values)
-}
-
-fn extract_named_value_map(entries: &Map<String, Value>) -> Option<Vec<String>> {
-    let mut numbered_entries = entries
-        .iter()
-        .filter_map(|(key, value)| Some((key.parse::<usize>().ok()?, value.as_str()?)))
-        .collect::<Vec<_>>();
-    numbered_entries.sort_by_key(|(index, _)| *index);
-
-    if numbered_entries.is_empty() {
-        return None;
-    }
-
-    normalize_class_names(
-        numbered_entries
-            .into_iter()
-            .map(|(_, value)| value.to_string())
-            .collect(),
-    )
-}
-
-fn extract_class_names_from_value(value: &Value) -> Option<Vec<String>> {
-    match value {
-        Value::Array(entries) => extract_named_value_list(entries),
-        Value::Object(entries) => {
-            for key in ["classNames", "class_names", "names", "labels", "classes"] {
-                if let Some(candidate) = entries.get(key).and_then(extract_class_names_from_value) {
-                    return Some(candidate);
-                }
-            }
-            extract_named_value_map(entries)
-        }
-        _ => None,
-    }
-}
-
 fn parse_config_class_names(config_path: &str) -> Result<Option<Vec<String>>, AppError> {
     if config_path.trim().is_empty() {
         return Ok(None);
@@ -1144,36 +1002,6 @@ fn parse_config_class_names(config_path: &str) -> Result<Option<Vec<String>>, Ap
     };
 
     Ok(extract_class_names_from_value(&parsed))
-}
-
-fn builtin_class_names(family: &str, category: &str) -> Option<Vec<String>> {
-    if category.eq_ignore_ascii_case("detection")
-        && matches!(
-            family.trim().to_ascii_lowercase().as_str(),
-            "yolo26" | "yolo11" | "yolov8"
-        )
-    {
-        return Some(
-            COCO_80_CLASS_NAMES
-                .iter()
-                .map(|value| value.to_string())
-                .collect(),
-        );
-    }
-
-    None
-}
-
-fn model_extension(model_path: &Path) -> String {
-    model_path
-        .extension()
-        .and_then(|value| value.to_str())
-        .unwrap_or_default()
-        .to_ascii_lowercase()
-}
-
-fn is_pytorch_checkpoint(model_path: &Path) -> bool {
-    matches!(model_extension(model_path).as_str(), "pt" | "pth")
 }
 
 fn trim_command_detail(detail: &str) -> String {
@@ -1317,38 +1145,6 @@ fn prepare_model_asset_for_inference(model_path: &Path) -> PreparedModelAsset {
             })),
         },
     }
-}
-
-/// Ultralytics-style filename suffix → task, authoritative over the installed
-/// category (a `-cls`/`-seg`/`-pose` asset is that task even if it was downloaded
-/// under a "detection" catalog entry). Returns `None` for plain detectors.
-fn task_suffix(model_path: &Path) -> Option<&'static str> {
-    let name = model_path
-        .file_name()
-        .and_then(|value| value.to_str())
-        .unwrap_or_default()
-        .to_lowercase();
-    if name.contains("-cls") || name.contains("_cls") {
-        Some("classification")
-    } else if name.contains("-pose") || name.contains("_pose") {
-        Some("pose")
-    } else if name.contains("-seg") || name.contains("_seg") {
-        Some("segmentation")
-    } else {
-        None
-    }
-}
-
-/// Accurate, role-aware reason a model can't run the box detector — segmentation
-/// models are usable (via the copilot), classification/pose are different tasks.
-fn non_detection_reason(task: &str) -> String {
-    match task {
-        "segmentation" => "Segmentation model \u{2014} used by the AI Copilot for click/box \u{2192} polygon (ask it to \u{201c}outline them\u{201d}), not the Detect button.",
-        "classification" => "Classification model \u{2014} it labels the whole image, not regions. Install a detection model (e.g. YOLO26 Detection) to draw boxes.",
-        "pose" => "Pose-estimation model \u{2014} not a box detector. Install a detection model for AI detect.",
-        _ => "AI detect supports object-detection models; this model uses a different task.",
-    }
-    .to_string()
 }
 
 fn prediction_unsupported_reason(
@@ -1664,14 +1460,6 @@ fn draft_matches_class(draft: &InferenceAnnotationDraft, target: &str) -> bool {
     .any(|value| class_token_matches(value.trim(), &target))
 }
 
-/// Singular/plural-tolerant equality for two already-lowercased class tokens.
-fn class_token_matches(a: &str, b: &str) -> bool {
-    if a.is_empty() || b.is_empty() {
-        return false;
-    }
-    a == b || format!("{a}s") == b || format!("{b}s") == a
-}
-
 /// Best-effort mapping from an installed `ai_models` entity to a registry plugin
 /// id (see [`crate::domain::ai::registry`]), used when the caller didn't pass an
 /// explicit `registryId`. The frontend normally passes the id of the catalog
@@ -1721,104 +1509,6 @@ fn registry_id_for_model(model: &Value) -> String {
     } else {
         "unknown".to_string()
     }
-}
-
-fn infer_model_family_and_variant(name: &str, model_path: &Path) -> (String, String) {
-    let haystack = format!(
-        "{} {}",
-        name.to_ascii_lowercase(),
-        model_path
-            .file_name()
-            .and_then(|value| value.to_str())
-            .unwrap_or_default()
-            .to_ascii_lowercase()
-    );
-
-    let family = if haystack.contains("yoloe-26") {
-        "yoloe-26"
-    } else if haystack.contains("yolo26") {
-        "yolo26"
-    } else if haystack.contains("yolo11") {
-        "yolo11"
-    } else if haystack.contains("yolov8") {
-        "yolov8"
-    } else {
-        ""
-    };
-
-    let variant = ["n", "s", "m", "l", "x"]
-        .iter()
-        .copied()
-        .find(|variant| {
-            haystack.contains(&format!("yolo26{variant}"))
-                || haystack.contains(&format!("yoloe-26{variant}"))
-        })
-        .unwrap_or_default();
-
-    (family.to_string(), variant.to_string())
-}
-
-fn infer_default_rank(family: &str, category: &str, variant: &str) -> i64 {
-    if family == "yolo26" && category == "detection" {
-        match variant {
-            "n" => 0,
-            "s" => 10,
-            "m" => 20,
-            "l" => 30,
-            "x" => 40,
-            _ => 100,
-        }
-    } else if family == "yolo26" {
-        50
-    } else if family == "yoloe-26" {
-        100
-    } else {
-        999
-    }
-}
-
-fn infer_model_runtime(model_path: &Path) -> (&'static str, &'static str) {
-    match model_extension(model_path).as_str() {
-        "onnx" => ("onnx", "ort"),
-        "pt" | "pth" => ("pytorch", "cpu"),
-        "tflite" => ("tflite", "cpu"),
-        "h5" => ("keras", "cpu"),
-        "pb" => ("tensorflow", "cpu"),
-        _ => ("unknown", "cpu"),
-    }
-}
-
-fn task_type_for_category(category: &str) -> &'static str {
-    match category {
-        "segmentation" => "segmentation",
-        "classification" => "classification",
-        "pose" => "pose_estimation",
-        "tracking" => "tracking",
-        _ => "object_detection",
-    }
-}
-
-fn build_model_version(
-    name: &str,
-    version: &str,
-    family: &str,
-    variant: &str,
-    category: &str,
-) -> String {
-    if !family.is_empty() && !variant.is_empty() {
-        let base = if family == "yoloe-26" {
-            format!("YOLOE-26{variant}")
-        } else {
-            format!("YOLO26{variant}")
-        };
-
-        return match category {
-            "segmentation" => format!("{base}-seg"),
-            "pose" => format!("{base}-pose"),
-            _ => base,
-        };
-    }
-    format!("{name} {version}")
 }
 
 fn file_name_from_path(path: &Path, invalid_message: &str) -> Result<String, AppError> {

--- a/apps/studio/src-tauri/src/domain/analysis/mod.rs
+++ b/apps/studio/src-tauri/src/domain/analysis/mod.rs
@@ -1,4 +1,4 @@
 pub mod commands;
-pub mod engine;
 pub mod model;
+pub mod repository;
 pub mod service;

--- a/apps/studio/src-tauri/src/domain/analysis/repository.rs
+++ b/apps/studio/src-tauri/src/domain/analysis/repository.rs
@@ -1,0 +1,92 @@
+//! Composition-root adapter: the `vailabel-analysis` persistence port over the
+//! residual `DesktopStore`. Source rows go through the generic `list_by_field`
+//! entity store; reports use the dedicated `analysis_reports` JSON-blob table.
+//! Keeping the store here (rather than moving the table into the crate) makes
+//! the analysis migration logic-only; the crate stays unaware of Diesel/SQLite.
+
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use serde_json::Value;
+use vailabel_analysis::domain::{AnalysisReport, AnalysisRepository, ReportSummary};
+use vailabel_core::{DomainError, DomainResult};
+
+use crate::store::DesktopStore;
+
+/// Map any store failure into the domain's repository variant.
+fn repo(error: impl ToString) -> DomainError {
+    DomainError::repository(error.to_string())
+}
+
+pub struct AnalysisStoreRepository {
+    store: Arc<Mutex<DesktopStore>>,
+}
+
+impl AnalysisStoreRepository {
+    pub fn new(store: Arc<Mutex<DesktopStore>>) -> Self {
+        Self { store }
+    }
+
+    fn guard(&self) -> DomainResult<MutexGuard<'_, DesktopStore>> {
+        self.store
+            .lock()
+            .map_err(|_| DomainError::repository("Desktop store is unavailable"))
+    }
+}
+
+impl AnalysisRepository for AnalysisStoreRepository {
+    fn list_images(&self, project_id: &str) -> DomainResult<Vec<Value>> {
+        self.guard()?
+            .list_by_field("images", "project_id", project_id)
+            .map_err(repo)
+    }
+
+    fn list_annotations(&self, project_id: &str) -> DomainResult<Vec<Value>> {
+        self.guard()?
+            .list_by_field("annotations", "project_id", project_id)
+            .map_err(repo)
+    }
+
+    fn list_labels(&self, project_id: &str) -> DomainResult<Vec<Value>> {
+        self.guard()?
+            .list_by_field("labels", "project_id", project_id)
+            .map_err(repo)
+    }
+
+    fn upsert_report(&self, report: &AnalysisReport) -> DomainResult<()> {
+        let summary = ReportSummary {
+            id: report.id.clone(),
+            project_id: report.project_id.clone(),
+            created_at: report.created_at.clone(),
+            image_count: report.image_count,
+            annotation_count: report.annotation_count,
+            health: report.health.clone(),
+        };
+        let summary_json = serde_json::to_string(&summary).map_err(repo)?;
+        let report_json = serde_json::to_string(report).map_err(repo)?;
+        self.guard()?
+            .upsert_analysis_report(
+                &report.id,
+                &report.project_id,
+                &report.created_at,
+                &summary_json,
+                &report_json,
+            )
+            .map_err(repo)
+    }
+
+    fn list_reports(&self, project_id: &str) -> DomainResult<Vec<Value>> {
+        self.guard()?.list_analysis_reports(project_id).map_err(repo)
+    }
+
+    fn get_report(&self, id: &str) -> DomainResult<Option<Value>> {
+        self.guard()?.get_analysis_report(id).map_err(repo)
+    }
+
+    fn latest_report(&self, project_id: &str) -> DomainResult<Option<Value>> {
+        self.guard()?.latest_analysis_report(project_id).map_err(repo)
+    }
+
+    fn delete_report(&self, id: &str) -> DomainResult<()> {
+        self.guard()?.delete_analysis_report(id).map_err(repo)
+    }
+}

--- a/apps/studio/src-tauri/src/domain/analysis/service.rs
+++ b/apps/studio/src-tauri/src/domain/analysis/service.rs
@@ -1,10 +1,10 @@
-//! Orchestration for Dataset Intelligence: spins the analysis engine on a
-//! background worker thread, streams progress to the UI via the
-//! `analysis://progress` event, and persists the finished report to SQLite.
+//! Background-job glue for Dataset Intelligence.
 //!
-//! The heavy work (decoding 1000+ images) must never block a Tauri command, so
-//! [`AnalysisService::start`] returns a job handle immediately and the real
-//! work happens in [`run_job`].
+//! Thin facade over the `vailabel-analysis` [`AnalysisAppService`]: report CRUD
+//! forwards straight through. The binary owns the job map, the worker thread,
+//! and the `analysis://progress` Tauri event, delivered to the crate's use case
+//! through the [`AnalysisReporter`] port. Domain errors convert to `AppError`
+//! via the `From` impl in `crate::composition`.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -14,43 +14,49 @@ use serde_json::Value;
 use tauri::{AppHandle, Emitter};
 use uuid::Uuid;
 
-use crate::store::DesktopStore;
+use vailabel_analysis::application::{AnalysisAppService, AnalysisReporter};
+use vailabel_analysis::contracts::AnalysisRequest;
+use vailabel_analysis::domain::AnalysisJob;
+
 use crate::{now_iso, AppError};
 
-use super::engine::{self, MetadataAnalysis, PixelMetrics, PixelOutcome};
-use super::model::*;
-
 pub const PROGRESS_EVENT: &str = "analysis://progress";
-/// Emit a progress event at most every this many processed images.
-const PROGRESS_EVERY: usize = 25;
 
 type JobMap = Arc<Mutex<HashMap<String, AnalysisJob>>>;
 
+/// Forwards report CRUD to the app service; owns the analysis job lifecycle.
 #[derive(Clone)]
 pub struct AnalysisService {
-    store: Arc<Mutex<DesktopStore>>,
+    app: Arc<AnalysisAppService>,
     jobs: JobMap,
 }
 
 impl AnalysisService {
-    pub fn new(store: Arc<Mutex<DesktopStore>>) -> Self {
+    pub fn new(app: Arc<AnalysisAppService>) -> Self {
         Self {
-            store,
+            app,
             jobs: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
     /// Queue an analysis and return its job handle. The actual work runs on a
     /// detached worker thread.
-    pub fn start(&self, app: &AppHandle, request: AnalysisRequest) -> Result<AnalysisJob, AppError> {
-        let job = AnalysisJob::new(Uuid::new_v4().to_string(), request.project_id.clone(), now_iso());
+    pub fn start(
+        &self,
+        app: &AppHandle,
+        request: AnalysisRequest,
+    ) -> Result<AnalysisJob, AppError> {
+        let job = AnalysisJob::new(
+            Uuid::new_v4().to_string(),
+            request.project_id.clone(),
+            now_iso(),
+        );
         self.put_job(job.clone());
 
-        let store = self.store.clone();
-        let jobs = self.jobs.clone();
+        let service = self.clone();
         let app = app.clone();
         let job_id = job.job_id.clone();
-        thread::spawn(move || run_job(store, jobs, app, request, job_id));
+        thread::spawn(move || service.run_job(&app, request, job_id));
 
         Ok(job)
     }
@@ -60,26 +66,44 @@ impl AnalysisService {
     }
 
     pub fn list_reports(&self, project_id: &str) -> Result<Vec<Value>, AppError> {
-        Ok(self.guard()?.list_analysis_reports(project_id)?)
+        Ok(self.app.list_reports(project_id)?)
     }
 
     pub fn get_report(&self, id: &str) -> Result<Option<Value>, AppError> {
-        Ok(self.guard()?.get_analysis_report(id)?)
+        Ok(self.app.get_report(id)?)
     }
 
     pub fn latest_report(&self, project_id: &str) -> Result<Option<Value>, AppError> {
-        Ok(self.guard()?.latest_analysis_report(project_id)?)
+        Ok(self.app.latest_report(project_id)?)
     }
 
-    pub fn delete_report(&self, id: &str) -> Result<Value, AppError> {
-        self.guard()?.delete_analysis_report(id)?;
-        Ok(serde_json::json!({ "success": true }))
+    pub fn delete_report(&self, id: &str) -> Result<(), AppError> {
+        Ok(self.app.delete_report(id)?)
     }
 
-    fn guard(&self) -> Result<std::sync::MutexGuard<'_, DesktopStore>, AppError> {
-        self.store
-            .lock()
-            .map_err(|_| AppError::Message("Desktop store is unavailable".into()))
+    fn run_job(&self, app: &AppHandle, request: AnalysisRequest, job_id: String) {
+        let mut reporter = TauriAnalysisReporter {
+            jobs: self.jobs.clone(),
+            app: app.clone(),
+            job_id: job_id.clone(),
+        };
+        match self.app.run(&request, &mut reporter) {
+            Ok(report_id) => {
+                update_job(&self.jobs, app, &job_id, |job| {
+                    job.status = "completed".into();
+                    job.stage = "Completed".into();
+                    job.progress = 1.0;
+                    job.report_id = Some(report_id.clone());
+                });
+            }
+            Err(err) => {
+                update_job(&self.jobs, app, &job_id, |job| {
+                    job.status = "failed".into();
+                    job.stage = "Failed".into();
+                    job.error = Some(err.to_string());
+                });
+            }
+        }
     }
 
     fn put_job(&self, job: AnalysisJob) {
@@ -89,334 +113,52 @@ impl AnalysisService {
     }
 }
 
-// ── Worker ──────────────────────────────────────────────────────────────────
-
-fn run_job(
-    store: Arc<Mutex<DesktopStore>>,
+/// Maps the crate's analysis progress hooks to job-map updates streamed over
+/// `analysis://progress`.
+struct TauriAnalysisReporter {
     jobs: JobMap,
     app: AppHandle,
-    request: AnalysisRequest,
     job_id: String,
-) {
-    match run_job_inner(&store, &jobs, &app, &request, &job_id) {
-        Ok(report_id) => {
-            update_job(&jobs, &app, &job_id, |job| {
-                job.status = "completed".into();
-                job.stage = "Completed".into();
-                job.progress = 1.0;
-                job.report_id = Some(report_id.clone());
-            });
-        }
-        Err(err) => {
-            update_job(&jobs, &app, &job_id, |job| {
-                job.status = "failed".into();
-                job.stage = "Failed".into();
-                job.error = Some(err.to_string());
-            });
-        }
-    }
 }
 
-fn run_job_inner(
-    store: &Arc<Mutex<DesktopStore>>,
-    jobs: &JobMap,
-    app: &AppHandle,
-    request: &AnalysisRequest,
-    job_id: &str,
-) -> Result<String, AppError> {
-    let cfg = &request.config;
-    let project_id = &request.project_id;
-
-    update_job(jobs, app, job_id, |job| {
-        job.status = "running".into();
-        job.stage = "Loading dataset".into();
-    });
-
-    // Snapshot the data under a brief lock, then release before heavy work.
-    let (images, annotations, labels) = {
-        let guard = store
-            .lock()
-            .map_err(|_| AppError::Message("Desktop store is unavailable".into()))?;
-        (
-            guard.list_by_field("images", "project_id", project_id)?,
-            guard.list_by_field("annotations", "project_id", project_id)?,
-            guard.list_by_field("labels", "project_id", project_id)?,
-        )
-    };
-
-    update_job(jobs, app, job_id, |job| {
-        job.stage = "Analyzing metadata".into();
-        job.total = images.len();
-        job.progress = 0.05;
-    });
-
-    let metadata = engine::analyze_metadata(&images, &annotations, &labels, cfg);
-
-    // ── Pixel pass (optional, slow) ─────────────────────────────────────────
-    let mut image_quality = ImageQualityReport::default();
-    let mut corrupted_images: Vec<ImageRef> = Vec::new();
-    let mut metrics: Vec<PixelMetrics> = Vec::new();
-
-    if cfg.include_image_quality {
-        let total = images.len();
-        for (index, image) in images.iter().enumerate() {
-            let id = image.get("id").and_then(Value::as_str).unwrap_or_default();
-            let name = image
-                .get("name")
-                .and_then(Value::as_str)
-                .unwrap_or("Untitled");
-            let path = image.get("path").and_then(Value::as_str).unwrap_or_default();
-
-            match engine::analyze_pixels(id, name, path, cfg) {
-                PixelOutcome::Metrics(metric) => {
-                    classify_image_quality(&metric, cfg, &mut image_quality);
-                    metrics.push(*metric);
-                    image_quality.analyzed += 1;
-                }
-                PixelOutcome::Corrupted(reason) => {
-                    corrupted_images.push(ImageRef {
-                        image_id: id.to_string(),
-                        name: name.to_string(),
-                        reason: Some(reason),
-                    });
-                }
-                PixelOutcome::Unsupported => {
-                    image_quality.skipped += 1;
-                }
-            }
-
-            if index % PROGRESS_EVERY == 0 || index + 1 == total {
-                let processed = index + 1;
-                update_job(jobs, app, job_id, |job| {
-                    job.processed = processed;
-                    job.stage = format!("Analyzing images ({processed}/{total})");
-                    // metadata done at 5%, pixel pass spans 5%..90%
-                    job.progress = 0.05 + 0.85 * (processed as f64 / total.max(1) as f64);
-                });
-            }
-        }
-    } else {
-        image_quality.skipped = images.len();
-    }
-
-    update_job(jobs, app, job_id, |job| {
-        job.stage = "Detecting outliers".into();
-        job.progress = 0.92;
-    });
-
-    let embedding_outliers = engine::embedding_outliers(&metrics, cfg.outlier_z_threshold);
-
-    // ── Assemble + persist ──────────────────────────────────────────────────
-    update_job(jobs, app, job_id, |job| {
-        job.stage = "Saving report".into();
-        job.progress = 0.97;
-    });
-
-    let report = build_report(project_id, metadata, image_quality, corrupted_images, embedding_outliers);
-    persist_report(store, &report)?;
-
-    Ok(report.id)
-}
-
-fn classify_image_quality(metric: &PixelMetrics, cfg: &AnalysisConfig, report: &mut ImageQualityReport) {
-    let make_ref = |reason: String| ImageQualityRef {
-        image_id: metric.image_id.clone(),
-        name: metric.name.clone(),
-        width: metric.width,
-        height: metric.height,
-        blur_score: metric.blur_score,
-        brightness: metric.brightness,
-        reason,
-    };
-
-    if metric.blur_score < cfg.blur_threshold {
-        report
-            .blurry
-            .push(make_ref(format!("Low sharpness ({:.0})", metric.blur_score)));
-    }
-    if metric.brightness >= cfg.overexposed_threshold || metric.clip_high > 0.6 {
-        report.overexposed.push(make_ref(format!(
-            "Bright ({:.0}%, {:.0}% clipped)",
-            metric.brightness * 100.0,
-            metric.clip_high * 100.0
-        )));
-    }
-    if metric.brightness <= cfg.underexposed_threshold || metric.clip_low > 0.6 {
-        report.underexposed.push(make_ref(format!(
-            "Dark ({:.0}%, {:.0}% clipped)",
-            metric.brightness * 100.0,
-            metric.clip_low * 100.0
-        )));
-    }
-
-    let long_edge = metric.width.max(metric.height) as f64;
-    let short_edge = metric.width.min(metric.height).max(1) as f64;
-    let aspect = long_edge / short_edge;
-    if metric.width < cfg.min_resolution || metric.height < cfg.min_resolution {
-        report.low_resolution.push(make_ref(format!(
-            "Small ({}×{})",
-            metric.width, metric.height
-        )));
-    } else if aspect > cfg.max_aspect_ratio {
-        report
-            .low_resolution
-            .push(make_ref(format!("Extreme aspect ratio ({aspect:.1}:1)")));
-    }
-}
-
-fn build_report(
-    project_id: &str,
-    metadata: MetadataAnalysis,
-    image_quality: ImageQualityReport,
-    corrupted_images: Vec<ImageRef>,
-    embedding_outliers: Vec<OutlierRef>,
-) -> AnalysisReport {
-    let MetadataAnalysis {
-        analytics,
-        missing_labels,
-        empty_annotations,
-        invalid_polygons,
-        rare_classes,
-        suspicious_labels,
-    } = metadata;
-
-    let quality = QualityValidation {
-        missing_labels,
-        empty_annotations,
-        invalid_polygons,
-        corrupted_images,
-    };
-    let outliers = OutlierReport {
-        embedding_outliers,
-        rare_classes,
-        suspicious_labels,
-    };
-
-    let findings = collect_findings(&quality, &image_quality, &outliers);
-    let health = health_summary(
-        &findings,
-        analytics.dataset_stats.total_images,
-        analytics.dataset_stats.total_annotations,
-    );
-
-    AnalysisReport {
-        id: Uuid::new_v4().to_string(),
-        project_id: project_id.to_string(),
-        created_at: now_iso(),
-        image_quality_analyzed: image_quality.analyzed > 0 || image_quality.skipped > 0,
-        image_count: analytics.dataset_stats.total_images,
-        annotation_count: analytics.dataset_stats.total_annotations,
-        label_count: analytics.label_distribution.len(),
-        health,
-        analytics,
-        quality,
-        image_quality,
-        outliers,
-        findings,
-    }
-}
-
-fn collect_findings(
-    quality: &QualityValidation,
-    image_quality: &ImageQualityReport,
-    outliers: &OutlierReport,
-) -> Vec<Finding> {
-    let mut findings = Vec::new();
-    let mut push = |category: &str, kind: &str, severity: &str, message: String, image_id: Option<String>, annotation_id: Option<String>, metric: Option<f64>| {
-        findings.push(Finding {
-            id: Uuid::new_v4().to_string(),
-            category: category.into(),
-            kind: kind.into(),
-            severity: severity.into(),
-            message,
-            image_id,
-            annotation_id,
-            metric,
+impl AnalysisReporter for TauriAnalysisReporter {
+    fn loading_dataset(&mut self) {
+        update_job(&self.jobs, &self.app, &self.job_id, |job| {
+            job.status = "running".into();
+            job.stage = "Loading dataset".into();
         });
-    };
-
-    for item in &quality.missing_labels {
-        push("quality", "missingLabels", "warning", format!("{}: no annotations", item.name), Some(item.image_id.clone()), None, None);
-    }
-    for item in &quality.empty_annotations {
-        push("quality", "emptyAnnotation", "error", format!("{} on {}: {}", item.label, item.image_name, item.reason), Some(item.image_id.clone()), Some(item.annotation_id.clone()), None);
-    }
-    for item in &quality.invalid_polygons {
-        push("quality", "invalidPolygon", "error", format!("{} on {}: {}", item.label, item.image_name, item.reason), Some(item.image_id.clone()), Some(item.annotation_id.clone()), None);
-    }
-    for item in &quality.corrupted_images {
-        push("quality", "corruptedImage", "error", format!("{}: {}", item.name, item.reason.clone().unwrap_or_default()), Some(item.image_id.clone()), None, None);
-    }
-    for item in &image_quality.blurry {
-        push("imageQuality", "blur", "warning", format!("{}: {}", item.name, item.reason), Some(item.image_id.clone()), None, Some(item.blur_score));
-    }
-    for item in &image_quality.overexposed {
-        push("imageQuality", "overexposed", "warning", format!("{}: {}", item.name, item.reason), Some(item.image_id.clone()), None, Some(item.brightness));
-    }
-    for item in &image_quality.underexposed {
-        push("imageQuality", "underexposed", "warning", format!("{}: {}", item.name, item.reason), Some(item.image_id.clone()), None, Some(item.brightness));
-    }
-    for item in &image_quality.low_resolution {
-        push("imageQuality", "lowResolution", "warning", format!("{}: {}", item.name, item.reason), Some(item.image_id.clone()), None, None);
-    }
-    for item in &outliers.embedding_outliers {
-        push("outlier", "embeddingOutlier", "info", format!("{}: {}", item.name, item.reason), Some(item.image_id.clone()), None, Some(item.score));
-    }
-    for item in &outliers.rare_classes {
-        push("outlier", "rareClass", "info", format!("Rare class '{}' ({} annotations)", item.label, item.count), None, None, Some(item.count as f64));
-    }
-    for item in &outliers.suspicious_labels {
-        push("outlier", "suspiciousLabel", "warning", format!("{} on {}: {}", item.label, item.image_name, item.reason), Some(item.image_id.clone()), Some(item.annotation_id.clone()), None);
     }
 
-    findings
-}
-
-fn health_summary(findings: &[Finding], image_count: usize, annotation_count: usize) -> HealthSummary {
-    let mut errors = 0;
-    let mut warnings = 0;
-    let mut infos = 0;
-    for finding in findings {
-        match finding.severity.as_str() {
-            "error" => errors += 1,
-            "warning" => warnings += 1,
-            _ => infos += 1,
-        }
+    fn analyzing_metadata(&mut self, total: usize) {
+        update_job(&self.jobs, &self.app, &self.job_id, |job| {
+            job.stage = "Analyzing metadata".into();
+            job.total = total;
+            job.progress = 0.05;
+        });
     }
-    let total_checks = (image_count + annotation_count).max(1) as f64;
-    let weighted = errors as f64 + warnings as f64 * 0.5 + infos as f64 * 0.1;
-    let score = (100.0 * (1.0 - weighted / total_checks)).clamp(0.0, 100.0);
-    HealthSummary {
-        errors,
-        warnings,
-        infos,
-        score,
+
+    fn analyzing_images(&mut self, processed: usize, total: usize) {
+        update_job(&self.jobs, &self.app, &self.job_id, |job| {
+            job.processed = processed;
+            job.stage = format!("Analyzing images ({processed}/{total})");
+            // metadata done at 5%, pixel pass spans 5%..90%
+            job.progress = 0.05 + 0.85 * (processed as f64 / total.max(1) as f64);
+        });
     }
-}
 
-fn persist_report(store: &Arc<Mutex<DesktopStore>>, report: &AnalysisReport) -> Result<(), AppError> {
-    let summary = ReportSummary {
-        id: report.id.clone(),
-        project_id: report.project_id.clone(),
-        created_at: report.created_at.clone(),
-        image_count: report.image_count,
-        annotation_count: report.annotation_count,
-        health: report.health.clone(),
-    };
-    let summary_json = serde_json::to_string(&summary)?;
-    let report_json = serde_json::to_string(report)?;
+    fn detecting_outliers(&mut self) {
+        update_job(&self.jobs, &self.app, &self.job_id, |job| {
+            job.stage = "Detecting outliers".into();
+            job.progress = 0.92;
+        });
+    }
 
-    let guard = store
-        .lock()
-        .map_err(|_| AppError::Message("Desktop store is unavailable".into()))?;
-    guard.upsert_analysis_report(
-        &report.id,
-        &report.project_id,
-        &report.created_at,
-        &summary_json,
-        &report_json,
-    )?;
-    Ok(())
+    fn saving_report(&mut self) {
+        update_job(&self.jobs, &self.app, &self.job_id, |job| {
+            job.stage = "Saving report".into();
+            job.progress = 0.97;
+        });
+    }
 }
 
 /// Mutate the stored job in place and broadcast the new state to the frontend.

--- a/apps/studio/src-tauri/src/lib.rs
+++ b/apps/studio/src-tauri/src/lib.rs
@@ -1000,8 +1000,20 @@ pub fn run() {
             let ai_service = Arc::new(crate::domain::ai::service::AiService::new(
                 entity_store.clone(),
             ));
+            // Analysis module: source rows + reports persist through a binary
+            // adapter over the residual store; the pixel decoder is the crate's
+            // infrastructure. The binary AnalysisService owns the job lifecycle.
+            let analysis_repo: Arc<dyn vailabel_analysis::domain::AnalysisRepository> = Arc::new(
+                crate::domain::analysis::repository::AnalysisStoreRepository::new(store_arc.clone()),
+            );
+            let analysis_decoder: Arc<dyn vailabel_analysis::application::ImageDecoder> =
+                Arc::new(vailabel_analysis::infrastructure::ImageQualityDecoder::new());
+            let analysis_app_service = Arc::new(vailabel_analysis::application::AnalysisAppService::new(
+                analysis_repo,
+                analysis_decoder,
+            ));
             let analysis_service = Arc::new(
-                crate::domain::analysis::service::AnalysisService::new(store_arc.clone()),
+                crate::domain::analysis::service::AnalysisService::new(analysis_app_service),
             );
             // Video module: persistence is a binary adapter over the residual
             // store; the FFmpeg pipeline is the crate's infrastructure. The


### PR DESCRIPTION
## Summary

Continues the DDD modular-monolith refactor (after #232, #233) by moving the **Dataset Intelligence** business logic out of `src/domain/analysis` into the `vailabel-analysis` crate, working toward emptying `src-tauri/src/domain`. The binary keeps only the background-job lifecycle (worker thread + the `analysis://progress` Tauri event).

IPC command responses and `analysis://progress` payloads are unchanged.

## What moved

**`vailabel-analysis` crate** (was a stub of domain types only — now fully layered):

| Layer | Contents |
|---|---|
| `domain/` | the pure `engine` — metadata analysis, geometry, outlier statistics, and the report-assembly helpers (`build_report`/`collect_findings`/`health_summary`/`classify_image_quality`) folded in from the old service — plus the `AnalysisRepository` port. No I/O. |
| `application/` | `AnalysisAppService` (the run pipeline + report CRUD) + the `ImageDecoder` (pixel pass) and `AnalysisReporter` (progress) ports |
| `infrastructure/` | `ImageQualityDecoder` — the `image`-crate decode + blur/exposure/embedding metrics, behind the port (the only layer that reads image files) |

**Binary side** ([apps/studio/src-tauri](apps/studio/src-tauri)):
- [src/domain/analysis/service.rs](apps/studio/src-tauri/src/domain/analysis/service.rs) — 437 → ~190-line facade. Forwards report CRUD; keeps the job map, worker thread, and `analysis://progress` emit, driving the crate through the `AnalysisReporter` port (the per-stage progress math + throttle live in the crate).
- [src/domain/analysis/repository.rs](apps/studio/src-tauri/src/domain/analysis/repository.rs) — new `AnalysisStoreRepository` adapting the port over the residual `DesktopStore` (source rows via `list_by_field`, reports via the `analysis_reports` table). **Logic-only** move, no schema surgery.
- `engine.rs` deleted from the binary (moved into the crate).
- [dependency_rules.rs](apps/studio/src-tauri/crates/arch-tests/tests/dependency_rules.rs) — `analysis` moves `FULLY_PURE` → `LAYERED` (its infra is the image decoder).

## Arch-test scanner fix

While migrating I hit a **false-positive in the dependency-rule scanner**: the forbidden token `ort::` (the ONNX `ort` crate) matched the *tail* of `ImageQualityReport::`. The scanner only guarded the `::` suffix (so `report`/`export` were safe) but not a leading boundary. Fixed the matcher to also require a non-identifier char *before* the token, so `Report::`/`export::`/`sort::` are excluded while real `ort::` / `tauri::` / `std::fs` paths still match — with a regression assertion added.

## Verification (all green)
- `cargo build -p vailabel-analysis` → clean
- `cargo test -p vailabel-arch-tests` → 4 passed (pure layers clean; `analysis` LAYERED; new scanner assertions)
- `cargo check` (binary, default `yolo-inference`) → clean, no warnings

## Notes
- Surfaced error strings carry the standard `DomainError` Display prefix, consistent with the other migrated modules.
- Remaining `src/domain` work after this: the large `ai`/copilot service and `runtime` glue, then relocating the per-module command/facade glue and removing the `domain/` folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
