### PR TITLE
docs: update macOS install app name

### DIFF
--- a/apps/web/docs/install-on-desktop.md
+++ b/apps/web/docs/install-on-desktop.md
@@ -46,7 +46,7 @@ Alternatively, you can right-click the app and select **Open**, then confirm.
 Alternatively, if you are on macOS and the app still won't open, you can try removing the quarantine attribute by running this command in your terminal:
 
 ```bash
-xattr -c /Applications/Vision\ AI\ Label\ Studio.app
+xattr -c /Applications/Vailabel\ Studio.app
 ```
 
 > **Warning:** This command removes all extended attributes (such as the 'quarantine' flag) from the application, which macOS may set when you download an app from the internet. Removing these attributes can help resolve issues where the app won't launch due to security restrictions. However, it will remove all extended attributes, not just the quarantine flag, and may bypass some of macOS's built-in security protections. Only use this if you trust the source of the application.


### PR DESCRIPTION
## Summary
- update the macOS quarantine command to target `/Applications/Vailabel\ Studio.app`
- keep the install guide consistent with the current desktop app name

## Verification
- `rg -n "xattr -c /Applications/(Vision|Vailabel)|Vision\\\\ AI\\\\ Label\\\\ Studio\.app|Vailabel\\\\ Studio\.app" apps/web/docs/install-on-desktop.md README.md`
- `git diff --check`

Closes #236