### PR TITLE
Log keyboard shortcut parse failures

### DIFF
--- a/apps/studio/src/shared/model/settings-viewmodel.ts
+++ b/apps/studio/src/shared/model/settings-viewmodel.ts
@@ -210,7 +210,9 @@ function parseKeyboardShortcuts(value: string): KeyboardShortcut[] {
     if (Array.isArray(parsed) && parsed.length > 0) {
       return parsed as KeyboardShortcut[]
     }
-  } catch {}
+  } catch (error) {
+    console.warn("Failed to parse keyboard shortcuts, using defaults", error)
+  }
 
   return [...DEFAULT_KEYBOARD_SHORTCUTS]
 }


### PR DESCRIPTION
﻿Fixes #251.

`parseKeyboardShortcuts` still falls back to the default shortcuts when stored settings are malformed, but it now logs the parse failure before doing so. That keeps the current recovery behavior while making corrupted shortcut JSON easier to diagnose.

Checked locally:
- `corepack yarn workspace @vailabel/studio typecheck`
- `rg "catch \{\}" apps/studio/src/shared/model/settings-viewmodel.ts`

I also ran lint. It still fails on existing rules in the current tree, including the pre-existing `react-hooks/set-state-in-effect` warning in this same file at `loadSettings()` and other unrelated files. This change does not add a new lint failure.
