### PR TITLE
fix(settings): log when keyboard shortcuts fail to parse

### DIFF
--- a/apps/studio/src/shared/model/settings-viewmodel.ts
+++ b/apps/studio/src/shared/model/settings-viewmodel.ts
@@ -210,7 +210,9 @@ function parseKeyboardShortcuts(value: string): KeyboardShortcut[] {
     if (Array.isArray(parsed) && parsed.length > 0) {
       return parsed as KeyboardShortcut[]
     }
-  } catch {}
+  } catch (err) {
+    console.warn("Failed to parse keyboard shortcuts, using defaults", err)
+  }
 
   return [...DEFAULT_KEYBOARD_SHORTCUTS]
 }


### PR DESCRIPTION
Closes #251

## Problem
`parseKeyboardShortcuts` wrapped `JSON.parse` in an empty `catch {}`. When a user's stored shortcuts are malformed, the error is swallowed silently and custom shortcuts reset to defaults with no signal — making it hard to diagnose why.

## Fix
Replaced the empty catch with a `console.warn` that logs the failure, while still falling back to `DEFAULT_KEYBOARD_SHORTCUTS`:

```ts
} catch (err) {
  console.warn("Failed to parse keyboard shortcuts, using defaults", err)
}
```

`console.warn` matches the existing logging style already used across the studio app (e.g. `canvas-utils.ts`); there's no project logger abstraction in this package.

## Acceptance criteria
- ✅ Parse failures are now logged
- ✅ Defaults are still returned
- ✅ No empty `catch {}` left in this function

## Verification
- `tsc --noEmit` (typecheck): passes
- `eslint` on the changed file: no new issues (the one remaining error in this file is a pre-existing `react-hooks/set-state-in-effect` at line 62, unrelated to this change)