### PR TITLE
docs: add keyboard shortcuts reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 
 - [Features](#features)
 - [Download](#download)
+- [Keyboard shortcuts](docs/keyboard-shortcuts.md)
 - [Development](#development)
 - [Project structure](#project-structure)
 - [Architecture](#architecture)

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -1,0 +1,60 @@
+# Keyboard Shortcuts
+
+This page lists the Studio shortcuts implemented in the current frontend code.
+The shortcuts are ignored while focus is inside an input, textarea, select, or
+editable text area.
+
+## Tool Selection
+
+| Action | Shortcut (Win/Linux) | Shortcut (macOS) |
+| --- | --- | --- |
+| Move tool | `M` | `M` |
+| Draw box | `B` | `B` |
+| Draw polygon | `P` | `P` |
+| Free draw | `F` | `F` |
+| Point tool | `O` | `O` |
+| Line tool | `L` | `L` |
+| Line strip tool | `S` | `S` |
+| Circle tool | `C` | `C` |
+| Smart Segment (SAM) tool | `G` | `G` |
+| Delete tool | `D` | `D` |
+
+## Canvas Editing
+
+| Action | Shortcut (Win/Linux) | Shortcut (macOS) |
+| --- | --- | --- |
+| Undo | `Ctrl+Z` | `Cmd+Z` |
+| Redo | `Ctrl+Shift+Z` or `Ctrl+Y` | `Cmd+Shift+Z` or `Cmd+Y` |
+| Delete selected annotation | `Delete` or `Backspace` | `Delete` or `Backspace` |
+| Nudge selected annotation by 1 px | Arrow keys | Arrow keys |
+| Nudge selected annotation by 10 px | `Shift` + Arrow keys | `Shift` + Arrow keys |
+| Pan while held | `Space` | `Space` |
+| Zoom in | `+` or `=` | `+` or `=` |
+| Zoom out | `-` or `_` | `-` or `_` |
+| Zoom around cursor | `Ctrl`/`Alt` + mouse wheel | `Cmd`/`Alt` + mouse wheel |
+
+## Navigation And View Toggles
+
+| Action | Shortcut (Win/Linux) | Shortcut (macOS) |
+| --- | --- | --- |
+| Previous item | Left Arrow | Left Arrow |
+| Next item | Right Arrow | Right Arrow |
+| Toggle crosshair | `H` | `H` |
+| Toggle coordinates | `X` | `X` |
+| Toggle ruler | `R` | `R` |
+
+## Label Selection
+
+| Action | Shortcut (Win/Linux) | Shortcut (macOS) |
+| --- | --- | --- |
+| Select label 1-9 in palette order | `1`-`9` | `1`-`9` |
+| Clear active label | `0` or `Escape` | `0` or `Escape` |
+
+## Drawing In Progress
+
+| Action | Shortcut (Win/Linux) | Shortcut (macOS) |
+| --- | --- | --- |
+| Cancel the active draw operation | `Escape` | `Escape` |
+| Finish a polygon or line strip | `Enter` | `Enter` |
+| Remove the last polygon or line-strip point | `Backspace` or `Delete` | `Backspace` or `Delete` |
+| Constrain a box while drawing | Hold `Shift` | Hold `Shift` |


### PR DESCRIPTION
## Summary
- add a Studio keyboard shortcuts reference built from the existing keyboard handlers and tool registry
- link the new shortcut reference from the README table of contents

Fixes #245

## Validation
- git diff --check
- Attempted `corepack yarn lint`; it could not run because `eslint` was not installed locally. `corepack yarn install --frozen-lockfile` timed out before dependencies finished installing.