### PR TITLE
test: add unit tests for itemKind

### DIFF
--- a/apps/studio/src/shared/lib/item-kind.test.ts
+++ b/apps/studio/src/shared/lib/item-kind.test.ts
@@ -1,0 +1,28 @@
+import { itemKind } from "./item-kind"
+import type { Item } from "@/shared/types/core"
+
+const baseItem: Item = {
+  id: "item-1",
+  name: "test-item",
+  width: 100,
+  height: 100,
+  path: "",
+}
+
+describe("itemKind", () => {
+  it("classifies image extensions", () => {
+    expect(itemKind({ ...baseItem, path: "photo.png" })).toBe("image")
+  })
+
+  it("classifies audio extensions", () => {
+    expect(itemKind({ ...baseItem, path: "clip.mp3" })).toBe("audio")
+  })
+
+  it("classifies tabular rows with inline data and no file path", () => {
+    expect(itemKind({ ...baseItem, data: {}, path: "" })).toBe("tabular")
+  })
+
+  it("falls back to text for unrecognized extensions", () => {
+    expect(itemKind({ ...baseItem, path: "notes.xyz" })).toBe("text")
+  })
+})


### PR DESCRIPTION
## Description
Adds a colocated Jest/Vitest test file for the `itemKind` utility in
`apps/studio/src/shared/lib/item-kind.ts`. Covers image and audio
classification by file extension, tabular rows with inline data
(empty path), and the text fallback for unrecognized extensions.

## Related issue
Closes #244

## Type of change
- [x] 🧹 Refactor / chore (no user-facing change)

## How has this been tested?
Ran `yarn test item-kind.test.ts` locally on Windows — all 4 tests
pass. Also ran `yarn typecheck`, which passes with no errors.

## Screenshots / recordings
N/A — test-only change, no UI impact.

## Checklist
- [x] My commits follow Conventional Commits.
- [x] I have added or updated tests for behavior changes.
- [ ] I have updated the documentation where needed.
- [x] `yarn lint`, `yarn typecheck`, and `yarn test` pass locally.
- [ ] New desktop work stays in Tauri + Rust.