### PR TITLE
fix(export): emit `image_id` in COCO annotations

### DIFF
--- a/apps/studio/src/features/studio/model/lib/export/coco-exporter.test.ts
+++ b/apps/studio/src/features/studio/model/lib/export/coco-exporter.test.ts
@@ -1,0 +1,97 @@
+import type { Annotation, Item, Label } from "@/shared/types/core"
+import { toCoco } from "./coco-exporter"
+
+type CocoDoc = {
+  images: Array<{ id: number; file_name: string; width: number; height: number }>
+  annotations: Array<Record<string, unknown>>
+  categories: Array<{ id: number; name: string }>
+}
+
+const image = (id: string, name: string): Item =>
+  ({ id, name, path: `/ds/${name}`, imagePath: name, width: 100, height: 50 }) as Item
+
+const box = (id: string, name: string, itemId: string): Annotation =>
+  ({
+    id,
+    name,
+    type: "box",
+    itemId,
+    coordinates: [
+      { x: 10, y: 20 },
+      { x: 30, y: 45 },
+    ],
+  }) as Annotation
+
+const polygon = (id: string, name: string, itemId: string): Annotation =>
+  ({
+    id,
+    name,
+    type: "polygon",
+    itemId,
+    coordinates: [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+    ],
+  }) as Annotation
+
+const labels = [{ id: "l1", name: "cat" } as Label, { id: "l2", name: "dog" } as Label]
+
+function build(): CocoDoc {
+  const images = [image("i1", "a.jpg"), image("i2", "b.jpg")]
+  const byImage = new Map<string, Annotation[]>([
+    ["i1", [box("a1", "cat", "i1"), polygon("a2", "dog", "i1")]],
+    ["i2", [box("a3", "dog", "i2")]],
+  ])
+  return toCoco(images, byImage, labels) as unknown as CocoDoc
+}
+
+describe("toCoco", () => {
+  // Regression: the image->item rename leaked into this external wire format and
+  // emitted `item_id`, which every COCO consumer (including our own importer)
+  // ignores — so a round-trip silently dropped every annotation.
+  it("links annotations to images with the spec's `image_id` field", () => {
+    const doc = build()
+
+    for (const annotation of doc.annotations) {
+      expect(annotation).toHaveProperty("image_id")
+      expect(annotation).not.toHaveProperty("item_id")
+    }
+
+    expect(doc.annotations.map((a) => a.image_id)).toEqual([1, 1, 2])
+  })
+
+  it("points every annotation's image_id at an existing image id", () => {
+    const doc = build()
+    const imageIds = new Set(doc.images.map((entry) => entry.id))
+
+    expect(doc.annotations).toHaveLength(3)
+    for (const annotation of doc.annotations) {
+      expect(imageIds.has(annotation.image_id as number)).toBe(true)
+    }
+  })
+
+  it("uses 1-based image, annotation and category ids", () => {
+    const doc = build()
+
+    expect(doc.images.map((entry) => entry.id)).toEqual([1, 2])
+    expect(doc.annotations.map((a) => a.id)).toEqual([1, 2, 3])
+    expect(doc.categories).toEqual([
+      { id: 1, name: "cat", supercategory: "" },
+      { id: 2, name: "dog", supercategory: "" },
+    ])
+    expect(doc.annotations.map((a) => a.category_id)).toEqual([1, 2, 2])
+  })
+
+  it("emits bbox for boxes and segmentation only for polygonal shapes", () => {
+    const doc = build()
+    const [boxAnn, polygonAnn] = doc.annotations
+
+    expect(boxAnn.bbox).toEqual([10, 20, 20, 25])
+    expect(boxAnn.segmentation).toEqual([])
+    expect(boxAnn.area).toBe(500)
+
+    expect(polygonAnn.segmentation).toEqual([[0, 0, 10, 0, 10, 10]])
+    expect(polygonAnn.area).toBe(50)
+  })
+})

--- a/apps/studio/src/features/studio/model/lib/export/coco-exporter.ts
+++ b/apps/studio/src/features/studio/model/lib/export/coco-exporter.ts
@@ -36,9 +36,12 @@ export function toCoco(
   let annotationId = 1
 
   images.forEach((image, imageIndex) => {
-    const itemId = imageIndex + 1
+    // COCO's own id for this image. Deliberately NOT called `itemId`: this is
+    // an external wire format, so the field stays `image_id` regardless of what
+    // we call the entity internally.
+    const cocoImageId = imageIndex + 1
     cocoImages.push({
-      id: itemId,
+      id: cocoImageId,
       file_name: image.imagePath || image.name,
       width: image.width,
       height: image.height,
@@ -54,7 +57,7 @@ export function toCoco(
       const polygonal = isPolygonal(annotation)
       cocoAnnotations.push({
         id: annotationId,
-        item_id: itemId,
+        image_id: cocoImageId,
         category_id: categoryId,
         bbox: [round(bbox.x), round(bbox.y), round(bbox.width), round(bbox.height)],
         area: round(


### PR DESCRIPTION
## The bug

COCO export produced an `annotations.json` that no COCO consumer can read.

Each exported annotation carried `item_id` instead of the spec-mandated `image_id`:

```jsonc
// apps/studio/src/features/studio/model/lib/export/coco-exporter.ts
{ "id": 1, "item_id": 1, "category_id": 1, "bbox": [...] }
//         ^^^^^^^ should be image_id
```

Because the link field is missing, annotations have no resolvable image:

- **Our own importer drops everything, silently.** `apps/studio/src-tauri/src/features/dataset/service.rs:626` does `let Some(image_id) = a.get("image_id") else { continue }` — so importing a file this app just exported yields **zero annotations and no error message**.
- **External tooling breaks the same way** — pycocotools, Detectron2, mmdetection, Ultralytics and Roboflow all key on `image_id`.

The `images` array and every other field were correct, so the file looks valid at a glance. That's what made it quiet.

## Root cause

Commit 514e8be (`refactor(rust|ui): refactor imnage to item`) renamed the internal entity `image` → `item` and swept `image_id` → `item_id` across the codebase. That rename is right for our own records (`Annotation.itemId` / `item_id`), but the COCO exporter writes an **external wire format** whose field names are fixed by the spec, so it should have been excluded:

```diff
   images.forEach((image, imageIndex) => {
-    const imageId = imageIndex + 1
+    const itemId = imageIndex + 1
...
-        image_id: imageId,
+        item_id: itemId,
```

I checked the sibling exporters (`yolo`, `voc`, `labelme`, `label-studio`) — their changes in that commit were type-only (`ImageData` → `Item`). COCO was the only external format affected.

## The fix

- Restore `image_id` on exported COCO annotations.
- Rename the local to `cocoImageId` with a comment explaining why it deliberately isn't called `itemId`, so a future rename sweep doesn't reintroduce this.

## Tests

New `coco-exporter.test.ts` (4 cases). The first two fail on `main` and pass here:

- asserts `image_id` is present and `item_id` is absent on every annotation
- asserts each `image_id` resolves to an id in the `images` array
- pins the 1-based image / annotation / category id scheme
- pins bbox-only for boxes vs. `segmentation` for polygonal shapes

Verified locally: `tsc --noEmit` clean, `eslint` clean, full suite **88 passed** (was 84).

🤖 Generated with [Claude Code](https://claude.com/claude-code)