### PR TITLE
refactor(projects): split detail + create routes, adopt shadcn primitives

### DIFF
--- a/apps/studio/src/features/projects/components/create/data-step.tsx
+++ b/apps/studio/src/features/projects/components/create/data-step.tsx
@@ -1,0 +1,161 @@
+import { memo, useCallback } from "react"
+import { Clapperboard, Clock, FileText, Film, ImageIcon, Table2 } from "lucide-react"
+import {
+  DATA_KIND_LABELS,
+  type LabelingTemplate,
+} from "@/shared/lib/label-config/labeling-templates"
+import type { LabelConfig } from "@/shared/lib/label-config/types"
+import type { ModalityDescriptor } from "@/features/projects/model/modality-registry"
+import { describeImport } from "@/features/projects/model/import-guide"
+import type { useProjectCreateViewModel } from "@/features/projects/model/project-create-viewmodel"
+import { Alert, AlertDescription } from "@/shared/ui/alert"
+import { FileDropZone } from "@/features/projects/components/file-drop-zone"
+import { ImageGrid } from "@/features/projects/components/image-upload"
+import { SelectedFileList } from "@/features/projects/components/selected-file-list"
+import { useFileDrop } from "@/features/projects/hooks/use-file-drop"
+import { ImportGuideCard } from "./import-guide-card"
+import { StagedPanel } from "./staged-panel"
+
+type ViewModel = ReturnType<typeof useProjectCreateViewModel>
+
+/** Spreadsheet imports can be huge; only this many rows are listed. */
+const ROW_PREVIEW_LIMIT = 200
+
+const plural = (count: number, noun: string) =>
+  `${count} ${noun}${count !== 1 ? "s" : ""}`
+
+/** Icon + heading for the staged non-image files, per modality. */
+function documentPresentation(descriptor: ModalityDescriptor) {
+  const isSpreadsheet = descriptor.importMode === "spreadsheet"
+  if (descriptor.kind === "video") {
+    return { icon: Clapperboard, rowIcon: FileText, title: "Selected videos", noun: "file" }
+  }
+  if (isSpreadsheet) {
+    return { icon: Table2, rowIcon: Table2, title: "Imported rows", noun: "row" }
+  }
+  if (descriptor.kind === "audio") {
+    return { icon: FileText, rowIcon: FileText, title: "Selected clips", noun: "file" }
+  }
+  return { icon: FileText, rowIcon: FileText, title: "Selected documents", noun: "file" }
+}
+
+/** Step 3 — import the data the chosen template expects. */
+export const DataStep = memo(
+  ({
+    viewModel,
+    selectedTemplate,
+    descriptor,
+    config,
+  }: {
+    viewModel: ViewModel
+    selectedTemplate?: LabelingTemplate
+    descriptor?: ModalityDescriptor
+    config: LabelConfig | null
+  }) => {
+    const isImage = descriptor?.kind === "image"
+    const isFiles = descriptor?.importMode === "files"
+    const isSpreadsheet = descriptor?.importMode === "spreadsheet"
+
+    const handleDrop = useCallback(
+      (paths: string[]) => {
+        if (!descriptor) return
+        const picked = paths.filter(descriptor.accepts)
+        if (descriptor.kind === "image") void viewModel.addImagePaths(picked)
+        else if (descriptor.importMode === "spreadsheet")
+          void viewModel.addSpreadsheetPaths(picked)
+        else if (descriptor.importMode === "files")
+          void viewModel.addDocumentPaths(picked, descriptor.grantScope)
+      },
+      [viewModel, descriptor]
+    )
+    const isOver = useFileDrop(handleDrop, isImage || isFiles || isSpreadsheet)
+
+    // Deferred-import kinds (video): clips are imported inside the studio editor.
+    if (descriptor?.importMode === "none") {
+      return (
+        <div className="mx-auto max-w-2xl">
+          <Alert>
+            <Film className="size-4" />
+            <AlertDescription>
+              Create the project, then import and process your video clips in the
+              studio — it extracts frames, detects scene cuts, and tracks objects
+              across time.
+            </AlertDescription>
+          </Alert>
+        </div>
+      )
+    }
+
+    // Unsupported kind: a roadmap template with no registered descriptor.
+    if (!descriptor) {
+      return (
+        <div className="mx-auto max-w-2xl">
+          <Alert>
+            <Clock className="size-4" />
+            <AlertDescription>
+              {selectedTemplate
+                ? `${DATA_KIND_LABELS[selectedTemplate.dataKind]} import isn't available yet — this template is on the roadmap.`
+                : "Pick a template first."}
+            </AlertDescription>
+          </Alert>
+        </div>
+      )
+    }
+
+    const guide = describeImport(descriptor, config)
+    const documents = documentPresentation(descriptor)
+
+    return (
+      <div className="mx-auto flex max-w-2xl flex-col gap-4">
+        <ImportGuideCard template={selectedTemplate} guide={guide} />
+
+        <FileDropZone
+          isOver={isOver}
+          busy={viewModel.isScanning}
+          onBrowse={() => void viewModel.openImport(descriptor)}
+          formats={guide.formats}
+        />
+
+        {isImage && viewModel.folderPath && (
+          <p className="truncate text-xs text-muted-foreground">
+            {viewModel.folderPath}
+          </p>
+        )}
+
+        {isImage && viewModel.images.length > 0 && (
+          <StagedPanel
+            icon={ImageIcon}
+            title="Selected images"
+            count={plural(viewModel.images.length, "file")}
+          >
+            <ImageGrid images={viewModel.images} onRemove={viewModel.removeImage} />
+          </StagedPanel>
+        )}
+
+        {(isFiles || isSpreadsheet) && viewModel.documents.length > 0 && (
+          <StagedPanel
+            icon={documents.icon}
+            title={documents.title}
+            count={plural(viewModel.documents.length, documents.noun)}
+          >
+            <SelectedFileList
+              files={viewModel.documents}
+              icon={documents.rowIcon}
+              onRemove={viewModel.removeDocument}
+              limit={ROW_PREVIEW_LIMIT}
+              scrollable
+            />
+            {isSpreadsheet && viewModel.documents.length > ROW_PREVIEW_LIMIT && (
+              <p className="text-xs text-muted-foreground">
+                Showing the first {ROW_PREVIEW_LIMIT} of{" "}
+                {viewModel.documents.length} rows.
+              </p>
+            )}
+          </StagedPanel>
+        )}
+      </div>
+    )
+  }
+)
+
+DataStep.displayName = "DataStep"

--- a/apps/studio/src/features/projects/components/create/import-guide-card.tsx
+++ b/apps/studio/src/features/projects/components/create/import-guide-card.tsx
@@ -1,0 +1,92 @@
+import { memo } from "react"
+import type { LabelingTemplate } from "@/shared/lib/label-config/labeling-templates"
+import type { ImportGuide } from "@/features/projects/model/import-guide"
+import { Badge } from "@/shared/ui/badge"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/shared/ui/card"
+
+function GuideSection({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="mt-3 border-t border-border pt-3">
+      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {title}
+      </p>
+      {children}
+    </div>
+  )
+}
+
+/**
+ * Tells the user exactly what to import for the chosen template — including the
+ * spreadsheet columns LLM-eval / tabular templates expect (derived from config).
+ */
+export const ImportGuideCard = memo(
+  ({ template, guide }: { template?: LabelingTemplate; guide: ImportGuide }) => {
+    const Icon = template?.icon
+
+    return (
+      <Card size="sm">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 font-semibold">
+            {Icon && <Icon className="size-4 shrink-0 text-primary" />}
+            {guide.title}
+          </CardTitle>
+          {template && (
+            <CardDescription className="text-xs">
+              for {template.label}
+            </CardDescription>
+          )}
+        </CardHeader>
+
+        <CardContent>
+          <p className="text-sm text-muted-foreground">{guide.detail}</p>
+
+          {guide.columns.length > 0 && (
+            <GuideSection title="Expected columns">
+              <div className="mt-1.5 flex flex-wrap gap-1.5">
+                {guide.columns.map((column) => (
+                  <Badge
+                    key={column.key}
+                    variant="outline"
+                    className="gap-1.5 bg-muted font-normal"
+                  >
+                    <code className="font-mono text-foreground">{column.key}</code>
+                    {column.label !== column.key && (
+                      <span className="text-muted-foreground">{column.label}</span>
+                    )}
+                  </Badge>
+                ))}
+              </div>
+              <p className="mt-1.5 text-xs text-muted-foreground">
+                Your file's header row should include these columns (extra columns
+                are ignored). To use different names, edit the field bindings in
+                Labeling Setup.
+              </p>
+            </GuideSection>
+          )}
+
+          {guide.example && (
+            <GuideSection title="Example">
+              <pre className="mt-1.5 overflow-x-auto rounded-md border border-border bg-muted/50 p-3 text-xs leading-relaxed text-foreground">
+                <code>{guide.example}</code>
+              </pre>
+            </GuideSection>
+          )}
+        </CardContent>
+      </Card>
+    )
+  }
+)
+
+ImportGuideCard.displayName = "ImportGuideCard"

--- a/apps/studio/src/features/projects/components/create/labeling-step.tsx
+++ b/apps/studio/src/features/projects/components/create/labeling-step.tsx
@@ -1,0 +1,87 @@
+import { memo, useMemo } from "react"
+import {
+  LABELING_TEMPLATES,
+  type LabelingTemplate,
+} from "@/shared/lib/label-config/labeling-templates"
+import type { ConfigInfo } from "@/features/projects/model/config-info"
+import { LabelingInterfaceEditor } from "@/features/projects/components/labeling-interface-editor"
+import { TemplateCard } from "./template-card"
+import { TemplateCategoryNav } from "./template-category-nav"
+
+/** Step 2 — pick a template, then tune the labeling interface it generated. */
+export const LabelingStep = memo(
+  ({
+    categories,
+    category,
+    onSelectCategory,
+    templateId,
+    selectedTemplate,
+    customTemplate,
+    configInfo,
+    labelConfig,
+    onLabelConfigChange,
+    onSelectTemplate,
+    onSelectCustom,
+  }: {
+    categories: readonly string[]
+    category: string
+    onSelectCategory: (category: string) => void
+    templateId: string
+    selectedTemplate?: LabelingTemplate
+    customTemplate?: LabelingTemplate
+    configInfo: ConfigInfo
+    labelConfig: string
+    onLabelConfigChange: (value: string) => void
+    onSelectTemplate: (template: LabelingTemplate) => void
+    onSelectCustom: (template: LabelingTemplate) => void
+  }) => {
+    const templates = useMemo(
+      () => LABELING_TEMPLATES.filter((template) => template.category === category),
+      [category]
+    )
+
+    return (
+      <div className="flex h-full">
+        <TemplateCategoryNav
+          categories={categories}
+          active={category}
+          onSelectCategory={onSelectCategory}
+          customTemplate={customTemplate}
+          onSelectCustom={onSelectCustom}
+        />
+
+        <div className="min-w-0 flex-1 overflow-y-auto p-5">
+          <div className="grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-4">
+            {templates.map((template) => (
+              <TemplateCard
+                key={template.id}
+                template={template}
+                selected={template.id === templateId}
+                onSelect={onSelectTemplate}
+              />
+            ))}
+          </div>
+
+          {selectedTemplate && (
+            <div className="mt-6 border-t border-border pt-5">
+              <p className="mb-3 text-sm font-semibold">
+                {selectedTemplate.label}{" "}
+                <span className="font-normal text-muted-foreground">
+                  · configure the interface
+                </span>
+              </p>
+              <LabelingInterfaceEditor
+                value={labelConfig}
+                onChange={onLabelConfigChange}
+                config={configInfo.config}
+                error={configInfo.error}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    )
+  }
+)
+
+LabelingStep.displayName = "LabelingStep"

--- a/apps/studio/src/features/projects/components/create/project-step.tsx
+++ b/apps/studio/src/features/projects/components/create/project-step.tsx
@@ -1,0 +1,45 @@
+import { memo } from "react"
+import { Field, FieldDescription, FieldGroup, FieldLabel } from "@/shared/ui/field"
+import { Input } from "@/shared/ui/input"
+import { Textarea } from "@/shared/ui/textarea"
+
+/** Step 1 — name and describe the project. */
+export const ProjectStep = memo(
+  ({
+    name,
+    description,
+    onNameChange,
+    onDescriptionChange,
+  }: {
+    name: string
+    description: string
+    onNameChange: (value: string) => void
+    onDescriptionChange: (value: string) => void
+  }) => (
+    <FieldGroup className="mx-auto max-w-xl">
+      <Field>
+        <FieldLabel htmlFor="project-name">Project name</FieldLabel>
+        <Input
+          id="project-name"
+          value={name}
+          onChange={(event) => onNameChange(event.target.value)}
+          placeholder="My dataset"
+          autoFocus
+        />
+      </Field>
+      <Field>
+        <FieldLabel htmlFor="project-description">Description</FieldLabel>
+        <Textarea
+          id="project-description"
+          value={description}
+          onChange={(event) => onDescriptionChange(event.target.value)}
+          placeholder="What is this dataset about?"
+          rows={3}
+        />
+        <FieldDescription>Optional.</FieldDescription>
+      </Field>
+    </FieldGroup>
+  )
+)
+
+ProjectStep.displayName = "ProjectStep"

--- a/apps/studio/src/features/projects/components/create/staged-panel.tsx
+++ b/apps/studio/src/features/projects/components/create/staged-panel.tsx
@@ -1,0 +1,27 @@
+import type * as React from "react"
+import { Badge } from "@/shared/ui/badge"
+
+/** Header + body wrapper for a list of files staged for import. */
+export function StagedPanel({
+  icon: Icon,
+  title,
+  count,
+  children,
+}: {
+  icon: React.ComponentType<{ className?: string }>
+  title: string
+  /** Already-pluralised count text, e.g. "3 files". */
+  count: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2">
+        <Icon className="size-5 text-primary" />
+        <span className="font-semibold">{title}</span>
+        <Badge variant="secondary">{count}</Badge>
+      </div>
+      {children}
+    </div>
+  )
+}

--- a/apps/studio/src/features/projects/components/create/template-card.tsx
+++ b/apps/studio/src/features/projects/components/create/template-card.tsx
@@ -1,0 +1,64 @@
+import { memo } from "react"
+import { Clock } from "lucide-react"
+import type { LabelingTemplate } from "@/shared/lib/label-config/labeling-templates"
+import { Badge } from "@/shared/ui/badge"
+import { TemplateIllustration } from "@/features/projects/components/template-illustrations"
+import { cn } from "@/shared/lib/utils"
+
+/** A template tile with an illustrated "thumbnail" header (gallery style). */
+export const TemplateCard = memo(
+  ({
+    template,
+    selected,
+    onSelect,
+  }: {
+    template: LabelingTemplate
+    selected: boolean
+    onSelect: (template: LabelingTemplate) => void
+  }) => {
+    const available = template.status === "available"
+
+    return (
+      <button
+        type="button"
+        disabled={!available}
+        onClick={() => onSelect(template)}
+        aria-pressed={selected}
+        className={cn(
+          "group flex flex-col overflow-hidden rounded-lg border text-left transition-all",
+          selected
+            ? "border-primary ring-2 ring-primary"
+            : available
+              ? "border-border hover:border-primary/50 hover:shadow-sm"
+              : "cursor-not-allowed border-dashed border-border opacity-60"
+        )}
+      >
+        <div className="aspect-[4/3] overflow-hidden bg-muted">
+          {template.image ? (
+            <img
+              src={template.image}
+              alt={template.label}
+              loading="lazy"
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <TemplateIllustration template={template} className="h-full w-full" />
+          )}
+        </div>
+        <div className="flex items-start gap-1.5 p-3">
+          <p className="min-w-0 flex-1 text-sm font-medium leading-snug">
+            {template.label}
+          </p>
+          {!available && (
+            <Badge variant="secondary" className="gap-1 text-warning">
+              <Clock className="size-3" />
+              Soon
+            </Badge>
+          )}
+        </div>
+      </button>
+    )
+  }
+)
+
+TemplateCard.displayName = "TemplateCard"

--- a/apps/studio/src/features/projects/components/create/template-category-nav.tsx
+++ b/apps/studio/src/features/projects/components/create/template-category-nav.tsx
@@ -1,0 +1,55 @@
+import { ChevronRight } from "lucide-react"
+import type { LabelingTemplate } from "@/shared/lib/label-config/labeling-templates"
+import { cn } from "@/shared/lib/utils"
+
+/** Left-hand category rail for the template gallery. */
+export function TemplateCategoryNav({
+  categories,
+  active,
+  onSelectCategory,
+  customTemplate,
+  onSelectCustom,
+}: {
+  categories: readonly string[]
+  active: string
+  onSelectCategory: (category: string) => void
+  /** The "Custom" template, pinned below the categories when available. */
+  customTemplate?: LabelingTemplate
+  onSelectCustom: (template: LabelingTemplate) => void
+}) {
+  return (
+    <nav className="w-56 shrink-0 overflow-y-auto border-r border-border py-2">
+      {categories.map((category) => (
+        <button
+          key={category}
+          type="button"
+          onClick={() => onSelectCategory(category)}
+          aria-current={category === active}
+          className={cn(
+            "flex w-full items-center justify-between gap-2 px-4 py-2 text-left text-sm transition-colors",
+            category === active
+              ? "bg-muted font-medium text-foreground"
+              : "text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+          )}
+        >
+          <span className="truncate">{category}</span>
+          <ChevronRight className="size-4 shrink-0 opacity-60" />
+        </button>
+      ))}
+
+      {customTemplate && (
+        <button
+          type="button"
+          onClick={() => onSelectCustom(customTemplate)}
+          aria-current={active === "Custom"}
+          className={cn(
+            "mt-1 w-full border-t border-border px-4 py-2 text-left text-sm font-medium text-primary transition-colors hover:bg-muted/50",
+            active === "Custom" && "bg-muted"
+          )}
+        >
+          Custom template
+        </button>
+      )}
+    </nav>
+  )
+}

--- a/apps/studio/src/features/projects/components/detail/add-data-tab.tsx
+++ b/apps/studio/src/features/projects/components/detail/add-data-tab.tsx
@@ -1,0 +1,71 @@
+import type { DatasetImportFormat } from "@/shared/types/ai-runtime"
+import type { DataKind } from "@/shared/lib/label-config/labeling-templates"
+import { descriptorForKind } from "@/features/projects/model/modality-registry"
+import type { useProjectDetailViewModel } from "@/features/projects/model/project-detail-viewmodel"
+import { DatasetImportCard } from "@/features/projects/components/dataset-import-card"
+import { DocumentImportPanel } from "./document-import-panel"
+import { ImageImportPanel } from "./image-import-panel"
+import { TabHeading } from "./tab-heading"
+
+type ViewModel = ReturnType<typeof useProjectDetailViewModel>
+
+/**
+ * Upload tab. The project's modality decides which importer is shown: image
+ * projects pick a folder (and can additionally import an annotated dataset),
+ * every other kind picks individual files.
+ */
+export function AddDataTab({
+  viewModel,
+  modality,
+  onImportDataset,
+}: {
+  viewModel: ViewModel
+  modality: DataKind
+  onImportDataset: (format?: DatasetImportFormat) => void
+}) {
+  const descriptor = descriptorForKind(modality)
+  // No descriptor means an unregistered kind; fall back to the folder importer.
+  const isImageModality = !descriptor || descriptor.importMode === "folder"
+
+  return (
+    <>
+      <TabHeading
+        title="Add data"
+        description="Bring your media into this project, and optionally import existing annotations. Files are referenced in place — nothing is copied."
+      />
+
+      <div className="flex flex-col gap-4">
+        {isImageModality ? (
+          <ImageImportPanel
+            images={viewModel.newImages}
+            isUploading={viewModel.isUploading}
+            isSaving={viewModel.isSaving}
+            onOpenFolder={viewModel.addImagesFromFolder}
+            onRemove={viewModel.handleRemoveImage}
+            onSave={viewModel.saveImages}
+          />
+        ) : (
+          <DocumentImportPanel
+            documents={viewModel.newDocuments}
+            kindLabel={descriptor.label}
+            fileLabel={modality === "audio" ? "clips" : "files"}
+            isUploading={viewModel.isUploading}
+            isSaving={viewModel.isSaving}
+            onSelectFiles={() =>
+              void viewModel.addDocumentFiles(descriptor.extensions)
+            }
+            onRemove={viewModel.handleRemoveDocument}
+            onSave={() => void viewModel.saveDocuments()}
+          />
+        )}
+
+        {isImageModality && (
+          <DatasetImportCard
+            isImporting={viewModel.isImporting}
+            onImport={onImportDataset}
+          />
+        )}
+      </div>
+    </>
+  )
+}

--- a/apps/studio/src/features/projects/components/detail/class-card.tsx
+++ b/apps/studio/src/features/projects/components/detail/class-card.tsx
@@ -1,0 +1,58 @@
+import type * as React from "react"
+import { Trash2 } from "lucide-react"
+import type { Label } from "@/shared/types/core"
+import { Badge } from "@/shared/ui/badge"
+import { Button } from "@/shared/ui/button"
+import { Card, CardContent } from "@/shared/ui/card"
+import { Progress } from "@/shared/ui/progress"
+
+/**
+ * One annotation class: swatch, name, count, delete, and a bar sized against
+ * the most-used class so the relative distribution is visible at a glance.
+ */
+export function ClassCard({
+  label,
+  count,
+  maxCount,
+  onDelete,
+  isDeleting,
+}: {
+  label: Label
+  count: number
+  maxCount: number
+  onDelete: () => void
+  isDeleting: boolean
+}) {
+  return (
+    <Card size="sm">
+      <CardContent className="flex flex-col gap-2.5">
+        <div className="flex items-center gap-2">
+          <span
+            className="size-3 shrink-0 rounded-full ring-1 ring-foreground/10"
+            style={{ backgroundColor: label.color }}
+          />
+          <span className="min-w-0 flex-1 truncate font-medium">{label.name}</span>
+          <Badge variant="secondary" className="tabular-nums">
+            {count}
+          </Badge>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={onDelete}
+            disabled={isDeleting}
+            className="text-muted-foreground hover:text-destructive"
+            aria-label={`Delete ${label.name}`}
+          >
+            <Trash2 />
+          </Button>
+        </div>
+        <Progress
+          value={Math.round((count / maxCount) * 100)}
+          aria-label={`${label.name} share of annotations`}
+          style={{ "--class-color": label.color } as React.CSSProperties}
+          className="[&_[data-slot=progress-indicator]]:bg-(--class-color)"
+        />
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/studio/src/features/projects/components/detail/classes-tab.tsx
+++ b/apps/studio/src/features/projects/components/detail/classes-tab.tsx
@@ -1,0 +1,83 @@
+import { Plus, Tag } from "lucide-react"
+import type { Label } from "@/shared/types/core"
+import { Badge } from "@/shared/ui/badge"
+import { Button } from "@/shared/ui/button"
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/shared/ui/empty"
+import { ClassCard } from "./class-card"
+import { TabHeading } from "./tab-heading"
+
+export function ClassesTab({
+  labels,
+  labelCounts,
+  maxLabelCount,
+  totalLabels,
+  isMutating,
+  onAddClass,
+  onDeleteClass,
+}: {
+  labels: Label[]
+  labelCounts: Map<string, number>
+  maxLabelCount: number
+  totalLabels: number
+  isMutating: boolean
+  onAddClass: () => void
+  onDeleteClass: (id: string) => void
+}) {
+  return (
+    <>
+      <TabHeading
+        title="Classes"
+        actions={
+          <>
+            <Badge variant="secondary">{totalLabels} total</Badge>
+            <Button size="sm" onClick={onAddClass}>
+              <Plus />
+              Add class
+            </Button>
+          </>
+        }
+      />
+
+      {labels.length > 0 ? (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {labels.map((label) => (
+            <ClassCard
+              key={label.id}
+              label={label}
+              count={labelCounts.get(label.id) ?? 0}
+              maxCount={maxLabelCount}
+              isDeleting={isMutating}
+              onDelete={() => onDeleteClass(label.id)}
+            />
+          ))}
+        </div>
+      ) : (
+        <Empty className="rounded-xl border border-dashed">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <Tag />
+            </EmptyMedia>
+            <EmptyTitle>No classes yet</EmptyTitle>
+            <EmptyDescription>
+              Add classes to start annotating, or they'll be created on the fly
+              while labeling.
+            </EmptyDescription>
+          </EmptyHeader>
+          <EmptyContent>
+            <Button onClick={onAddClass}>
+              <Plus />
+              Add your first class
+            </Button>
+          </EmptyContent>
+        </Empty>
+      )}
+    </>
+  )
+}

--- a/apps/studio/src/features/projects/components/detail/document-import-panel.tsx
+++ b/apps/studio/src/features/projects/components/detail/document-import-panel.tsx
@@ -1,0 +1,72 @@
+import { FileText, Plus } from "lucide-react"
+import { Badge } from "@/shared/ui/badge"
+import { Button } from "@/shared/ui/button"
+import { Spinner } from "@/shared/ui/spinner"
+import {
+  SelectedFileList,
+  type SelectedFile,
+} from "@/features/projects/components/selected-file-list"
+
+/** File-picker import for the non-image modalities (text, audio, …). */
+export function DocumentImportPanel({
+  documents,
+  kindLabel,
+  fileLabel,
+  isUploading,
+  isSaving,
+  onSelectFiles,
+  onRemove,
+  onSave,
+}: {
+  documents: SelectedFile[]
+  /** Human name of the modality, e.g. "Text". */
+  kindLabel: string
+  /** Unit noun for this modality, e.g. "clips" or "files". */
+  fileLabel: string
+  isUploading: boolean
+  isSaving: boolean
+  onSelectFiles: () => void
+  onRemove: (index: number) => void
+  onSave: () => void
+}) {
+  const kind = kindLabel.toLowerCase()
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <h3 className="font-medium">
+          Add {kind} {fileLabel}
+        </h3>
+        <Badge variant="secondary">{documents.length} selected</Badge>
+      </div>
+
+      <Button
+        variant="outline"
+        className="w-full gap-2"
+        onClick={onSelectFiles}
+        disabled={isUploading}
+      >
+        {isUploading ? <Spinner /> : <FileText className="size-5" />}
+        {isUploading ? "Opening…" : `Select ${kind} ${fileLabel}`}
+      </Button>
+
+      {documents.length > 0 && (
+        <>
+          <SelectedFileList
+            files={documents}
+            icon={FileText}
+            onRemove={onRemove}
+          />
+          <div className="flex justify-end">
+            <Button onClick={onSave} disabled={isUploading || isSaving}>
+              {isSaving ? <Spinner /> : <Plus />}
+              {isSaving
+                ? `Saving ${fileLabel}…`
+                : `Save ${documents.length} ${fileLabel}`}
+            </Button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/studio/src/features/projects/components/detail/image-import-panel.tsx
+++ b/apps/studio/src/features/projects/components/detail/image-import-panel.tsx
@@ -1,0 +1,55 @@
+import { FolderOpen, Plus } from "lucide-react"
+import type { Item as ProjectItem } from "@/shared/types/core"
+import { Badge } from "@/shared/ui/badge"
+import { Button } from "@/shared/ui/button"
+import { Spinner } from "@/shared/ui/spinner"
+import { ImageGrid } from "@/features/projects/components/image-upload"
+
+/** Folder-based image import (the default `image` modality). */
+export function ImageImportPanel({
+  images,
+  isUploading,
+  isSaving,
+  onOpenFolder,
+  onRemove,
+  onSave,
+}: {
+  images: ProjectItem[]
+  isUploading: boolean
+  isSaving: boolean
+  onOpenFolder: () => void
+  onRemove: (index: number) => void
+  onSave: () => void
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <h3 className="font-medium">Add images</h3>
+        <Badge variant="secondary">{images.length} selected</Badge>
+      </div>
+
+      <Button
+        variant="outline"
+        className="w-full gap-2"
+        onClick={onOpenFolder}
+        disabled={isUploading}
+      >
+        {isUploading ? <Spinner /> : <FolderOpen className="size-5" />}
+        {isUploading ? "Scanning folder…" : "Open image folder"}
+      </Button>
+
+      <ImageGrid images={images} onRemove={onRemove} />
+
+      {images.length > 0 && (
+        <div className="flex justify-end">
+          <Button onClick={onSave} disabled={isUploading || isSaving}>
+            {isSaving ? <Spinner /> : <Plus />}
+            {isSaving
+              ? "Saving images…"
+              : `Save ${images.length} image${images.length !== 1 ? "s" : ""}`}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/studio/src/features/projects/components/detail/labeling-progress-card.tsx
+++ b/apps/studio/src/features/projects/components/detail/labeling-progress-card.tsx
@@ -1,0 +1,28 @@
+import { Card, CardContent } from "@/shared/ui/card"
+import { Progress, ProgressLabel, ProgressValue } from "@/shared/ui/progress"
+
+/** Overall labeling completion for the project. */
+export function LabelingProgressCard({
+  annotatedItems,
+  totalItems,
+  progress,
+}: {
+  annotatedItems: number
+  totalItems: number
+  progress: number
+}) {
+  return (
+    <Card>
+      <CardContent>
+        <Progress value={progress} className="gap-y-2">
+          <ProgressLabel className="text-base text-foreground">
+            Labeling progress
+          </ProgressLabel>
+          <ProgressValue>
+            {() => `${annotatedItems} / ${totalItems} images · ${progress}%`}
+          </ProgressValue>
+        </Progress>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/studio/src/features/projects/components/detail/model-tab.tsx
+++ b/apps/studio/src/features/projects/components/detail/model-tab.tsx
@@ -1,0 +1,41 @@
+import { Brain } from "lucide-react"
+import { Button } from "@/shared/ui/button"
+import { ModelFlywheel } from "@/features/projects/components/model-flywheel"
+import { TrainingMonitor } from "@/shared/components/training/training-monitor"
+import { TabHeading } from "./tab-heading"
+
+export function ModelTab({
+  projectId,
+  annotatedItems,
+  totalItems,
+  onTrain,
+  onContinueLabeling,
+}: {
+  projectId: string | undefined
+  annotatedItems: number
+  totalItems: number
+  onTrain: () => void
+  onContinueLabeling: () => void
+}) {
+  return (
+    <>
+      <TabHeading
+        title="Project model"
+        description="This project trains its own model from your labels. Label a few → train → auto-label → correct → repeat; each cycle improves the model and the latest version pre-labels the rest."
+        actions={
+          <Button onClick={onTrain}>
+            <Brain />
+            Train new version
+          </Button>
+        }
+      />
+      <ModelFlywheel
+        projectId={projectId}
+        annotatedImages={annotatedItems}
+        totalItems={totalItems}
+        onContinueLabeling={onContinueLabeling}
+      />
+      <TrainingMonitor projectId={projectId} onUseForLabeling={onContinueLabeling} />
+    </>
+  )
+}

--- a/apps/studio/src/features/projects/components/detail/project-detail-header.tsx
+++ b/apps/studio/src/features/projects/components/detail/project-detail-header.tsx
@@ -1,0 +1,62 @@
+import { ArrowLeft, Calendar } from "lucide-react"
+import type { Project } from "@/shared/types/core"
+import { Badge } from "@/shared/ui/badge"
+import { Button } from "@/shared/ui/button"
+import { formatProjectDate } from "@/features/projects/model/format-date"
+
+/** Back link, project identity, and the row of actions. */
+export function ProjectDetailHeader({
+  project,
+  projectName,
+  onBack,
+  actions,
+}: {
+  project: Project | null | undefined
+  projectName: string
+  onBack: () => void
+  actions: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={onBack}
+        className="-ml-2 w-fit gap-1.5 text-muted-foreground"
+      >
+        <ArrowLeft />
+        Projects
+      </Button>
+
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="truncate text-2xl font-bold text-foreground">
+              {projectName}
+            </h1>
+            {project?.type && (
+              <Badge variant="secondary" className="capitalize">
+                {project.type}
+              </Badge>
+            )}
+            {project?.status && (
+              <Badge variant="outline" className="capitalize">
+                {project.status}
+              </Badge>
+            )}
+          </div>
+          <p className="max-w-2xl text-sm text-muted-foreground">
+            {project?.description?.trim() ||
+              "No description yet — edit the project to add one."}
+          </p>
+          <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <Calendar className="size-3.5" />
+            Created {formatProjectDate(project?.createdAt)}
+          </p>
+        </div>
+
+        {actions}
+      </div>
+    </div>
+  )
+}

--- a/apps/studio/src/features/projects/components/detail/project-detail-status.tsx
+++ b/apps/studio/src/features/projects/components/detail/project-detail-status.tsx
@@ -1,0 +1,49 @@
+import { CircleAlert } from "lucide-react"
+import { Button } from "@/shared/ui/button"
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/shared/ui/empty"
+import { Spinner } from "@/shared/ui/spinner"
+
+export function ProjectDetailLoading() {
+  return (
+    <Empty className="h-64">
+      <EmptyHeader>
+        <Spinner className="size-6" />
+        <EmptyDescription>Loading project data…</EmptyDescription>
+      </EmptyHeader>
+    </Empty>
+  )
+}
+
+export function ProjectDetailError({
+  error,
+  onRetry,
+}: {
+  error: unknown
+  onRetry: () => void
+}) {
+  return (
+    <Empty className="rounded-xl border border-dashed border-destructive/40">
+      <EmptyHeader>
+        <EmptyMedia variant="icon" className="bg-destructive/10 text-destructive">
+          <CircleAlert />
+        </EmptyMedia>
+        <EmptyTitle className="text-destructive">Error loading project</EmptyTitle>
+        <EmptyDescription>
+          {typeof error === "string" ? error : "An unexpected error occurred."}
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        <Button variant="outline" size="sm" onClick={onRetry}>
+          Try again
+        </Button>
+      </EmptyContent>
+    </Empty>
+  )
+}

--- a/apps/studio/src/features/projects/components/detail/project-stats-grid.tsx
+++ b/apps/studio/src/features/projects/components/detail/project-stats-grid.tsx
@@ -1,0 +1,55 @@
+import { BarChart3, CheckCircle2, ImageIcon, Layers } from "lucide-react"
+import { Card, CardContent } from "@/shared/ui/card"
+import {
+  Item,
+  ItemContent,
+  ItemDescription,
+  ItemMedia,
+  ItemTitle,
+} from "@/shared/ui/item"
+
+export interface ProjectStatsSummary {
+  totalItems: number
+  annotatedImages: number
+  totalAnnotations: number
+  totalLabels: number
+}
+
+/** The four headline counters above the tabs. */
+export function ProjectStatsGrid({ stats }: { stats: ProjectStatsSummary }) {
+  const tiles = [
+    { label: "Images", value: stats.totalItems, icon: ImageIcon },
+    {
+      label: "Annotated",
+      value: `${stats.annotatedImages} / ${stats.totalItems}`,
+      icon: CheckCircle2,
+    },
+    { label: "Annotations", value: stats.totalAnnotations, icon: BarChart3 },
+    { label: "Classes", value: stats.totalLabels, icon: Layers },
+  ]
+
+  return (
+    <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+      {tiles.map((tile) => (
+        <Card key={tile.label} size="sm">
+          <CardContent>
+            <Item size="sm" className="p-0">
+              <ItemMedia
+                variant="icon"
+                className="size-9 rounded-lg bg-muted text-muted-foreground"
+              >
+                <tile.icon className="size-4.5" />
+              </ItemMedia>
+              <ItemContent>
+                <ItemDescription className="text-xs">{tile.label}</ItemDescription>
+                <ItemTitle className="text-lg font-semibold tabular-nums">
+                  {tile.value}
+                </ItemTitle>
+              </ItemContent>
+            </Item>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}

--- a/apps/studio/src/features/projects/components/detail/project-toolbar.tsx
+++ b/apps/studio/src/features/projects/components/detail/project-toolbar.tsx
@@ -1,0 +1,112 @@
+import {
+  Clapperboard,
+  CloudDownload,
+  CloudUpload,
+  Edit,
+  Play,
+  RefreshCw,
+} from "lucide-react"
+import { Button } from "@/shared/ui/button"
+import { ButtonGroup } from "@/shared/ui/button-group"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/shared/ui/tooltip"
+import { cn } from "@/shared/lib/utils"
+
+/** Refresh / cloud sync / edit / start-labeling actions for the detail header. */
+export function ProjectToolbar({
+  isVideoProject,
+  onOpenVideoEditor,
+  onRefresh,
+  isLoading,
+  cloudTargetName,
+  isSyncing,
+  onPush,
+  onPull,
+  onEdit,
+  labelingCta,
+  canLabel,
+  onStartLabeling,
+}: {
+  isVideoProject: boolean
+  onOpenVideoEditor: () => void
+  onRefresh: () => void
+  isLoading: boolean
+  /** Name of the configured cloud target, or undefined when sync is off. */
+  cloudTargetName?: string
+  isSyncing: boolean
+  onPush: () => void
+  onPull: () => void
+  onEdit: () => void
+  labelingCta: string
+  canLabel: boolean
+  onStartLabeling: () => void
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {isVideoProject && (
+        <Button size="sm" onClick={onOpenVideoEditor}>
+          <Clapperboard />
+          Open video editor
+        </Button>
+      )}
+
+      <Button variant="outline" size="sm" onClick={onRefresh} disabled={isLoading}>
+        <RefreshCw className={cn(isLoading && "animate-spin")} />
+        Refresh
+      </Button>
+
+      {cloudTargetName && (
+        <TooltipProvider>
+          <ButtonGroup>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={onPush}
+                    disabled={isSyncing}
+                  >
+                    <CloudUpload className={cn(isSyncing && "animate-pulse")} />
+                    Push
+                  </Button>
+                }
+              />
+              <TooltipContent>Upload items to {cloudTargetName}</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={onPull}
+                    disabled={isSyncing}
+                  >
+                    <CloudDownload className={cn(isSyncing && "animate-pulse")} />
+                    Pull
+                  </Button>
+                }
+              />
+              <TooltipContent>Download items from {cloudTargetName}</TooltipContent>
+            </Tooltip>
+          </ButtonGroup>
+        </TooltipProvider>
+      )}
+
+      <Button variant="outline" size="sm" onClick={onEdit}>
+        <Edit />
+        Edit
+      </Button>
+
+      <Button size="sm" onClick={onStartLabeling} disabled={!canLabel}>
+        <Play />
+        {labelingCta}
+      </Button>
+    </div>
+  )
+}

--- a/apps/studio/src/features/projects/components/detail/tab-heading.tsx
+++ b/apps/studio/src/features/projects/components/detail/tab-heading.tsx
@@ -1,0 +1,24 @@
+import type * as React from "react"
+
+/** Title (+ optional blurb / actions) at the top of each detail tab. */
+export function TabHeading({
+  title,
+  description,
+  actions,
+}: {
+  title: string
+  description?: string
+  actions?: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-wrap items-start justify-between gap-3">
+      <div>
+        <h2 className="text-lg font-semibold">{title}</h2>
+        {description && (
+          <p className="max-w-2xl text-sm text-muted-foreground">{description}</p>
+        )}
+      </div>
+      {actions && <div className="flex items-center gap-2">{actions}</div>}
+    </div>
+  )
+}

--- a/apps/studio/src/features/projects/components/selected-file-list.tsx
+++ b/apps/studio/src/features/projects/components/selected-file-list.tsx
@@ -1,0 +1,72 @@
+import type * as React from "react"
+import { X } from "lucide-react"
+import { Button } from "@/shared/ui/button"
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemGroup,
+  ItemMedia,
+  ItemTitle,
+} from "@/shared/ui/item"
+import { cn } from "@/shared/lib/utils"
+
+export interface SelectedFile {
+  id: string
+  name: string
+  path?: string
+}
+
+/**
+ * The staged-files list shared by project creation and the detail Upload tab:
+ * one removable row per picked file. `limit` caps how many rows are rendered
+ * (spreadsheet imports can run to thousands of rows).
+ */
+export function SelectedFileList({
+  files,
+  icon: Icon,
+  onRemove,
+  limit,
+  scrollable = false,
+}: {
+  files: SelectedFile[]
+  icon: React.ComponentType<{ className?: string }>
+  onRemove: (index: number) => void
+  limit?: number
+  scrollable?: boolean
+}) {
+  const visible = limit ? files.slice(0, limit) : files
+
+  return (
+    <ItemGroup
+      className={cn(
+        "gap-0 divide-y divide-border rounded-lg border border-border",
+        scrollable && "max-h-72 overflow-y-auto"
+      )}
+    >
+      {visible.map((file, index) => (
+        <Item key={file.id} size="xs" className="px-3 py-2">
+          <ItemMedia>
+            <Icon className="size-4 shrink-0 text-muted-foreground" />
+          </ItemMedia>
+          <ItemContent>
+            <ItemTitle className="font-normal" title={file.path || file.name}>
+              {file.name}
+            </ItemTitle>
+          </ItemContent>
+          <ItemActions>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              onClick={() => onRemove(index)}
+              aria-label={`Remove ${file.name}`}
+              className="rounded-full text-muted-foreground"
+            >
+              <X />
+            </Button>
+          </ItemActions>
+        </Item>
+      ))}
+    </ItemGroup>
+  )
+}

--- a/apps/studio/src/features/projects/model/config-info.ts
+++ b/apps/studio/src/features/projects/model/config-info.ts
@@ -1,0 +1,55 @@
+import type { DataKind } from "@/shared/lib/label-config/labeling-templates"
+import type { LabelConfig } from "@/shared/lib/label-config/types"
+import { parseLabelConfig } from "@/shared/lib/label-config/parse"
+import { isMultiTextJudgement } from "@/shared/lib/label-config/infer"
+
+export interface ConfigInfo {
+  ok: boolean
+  config: LabelConfig | null
+  dataKind: DataKind
+  error: string | null
+}
+
+/** Object tags that map directly onto a data kind. */
+const DATA_OBJECT_TAGS = ["image", "text", "audio", "video", "table"]
+
+/**
+ * The labeling config is the single source of truth for validity, the data kind
+ * to import, and the visual editor + preview. Parses it once and reports all
+ * three, never throwing.
+ */
+export function deriveConfigInfo(source: string): ConfigInfo {
+  try {
+    const parsed = parseLabelConfig(source)
+
+    // The primary object tag maps to a data kind. For image/text/audio/video
+    // the tag IS the kind; the `table` object maps to the `tabular` kind.
+    const primary = parsed.objects.find((object) =>
+      DATA_OBJECT_TAGS.includes(object.tag)
+    )
+
+    // Multi-field LLM-eval tasks (prompt + responses) and explicit `table`
+    // objects are one-row-per-task, so they import via the spreadsheet path
+    // (each row carries its fields inline). Everything else maps the primary
+    // object tag straight to its data kind.
+    const dataKind: DataKind =
+      isMultiTextJudgement(parsed) || primary?.tag === "table"
+        ? "tabular"
+        : ((primary?.tag as DataKind) ?? "image")
+
+    const ok = parsed.objects.length > 0 && parsed.controls.length > 0
+    return {
+      ok,
+      config: parsed,
+      dataKind,
+      error: ok ? null : "Add a data object and at least one control.",
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      config: null,
+      dataKind: "image",
+      error: error instanceof Error ? error.message : "Invalid config",
+    }
+  }
+}

--- a/apps/studio/src/features/projects/model/format-date.ts
+++ b/apps/studio/src/features/projects/model/format-date.ts
@@ -1,0 +1,27 @@
+/**
+ * Date/time formatting shared by the project list and detail screens. Both
+ * return "Unknown" rather than throwing, so a malformed timestamp from an old
+ * record can never blank out a whole card.
+ */
+
+const format = (
+  date: Date | string | undefined,
+  options: Intl.DateTimeFormatOptions
+): string => {
+  if (!date) return "Unknown"
+  try {
+    const parsed = typeof date === "string" ? new Date(date) : date
+    if (Number.isNaN(parsed.getTime())) return "Unknown"
+    return new Intl.DateTimeFormat("en-US", options).format(parsed)
+  } catch {
+    return "Unknown"
+  }
+}
+
+/** e.g. "Mar 4, 2026". */
+export const formatProjectDate = (date: Date | string | undefined): string =>
+  format(date, { month: "short", day: "numeric", year: "numeric" })
+
+/** e.g. "09:41 AM". */
+export const formatProjectTime = (date: Date | string | undefined): string =>
+  format(date, { hour: "2-digit", minute: "2-digit" })

--- a/apps/studio/src/features/projects/model/use-project-detail-derivations.ts
+++ b/apps/studio/src/features/projects/model/use-project-detail-derivations.ts
@@ -1,0 +1,61 @@
+import { useMemo } from "react"
+import type { Annotation, Item, Label } from "@/shared/types/core"
+import { getLastItem } from "@/shared/lib/last-item"
+
+/**
+ * Values the detail screen derives from the loaded project data. Kept out of
+ * the component so the memo dependencies stay readable and testable.
+ */
+export function useProjectDetailDerivations({
+  projectId,
+  items,
+  annotations,
+  labels,
+}: {
+  projectId: string | undefined
+  items: Item[]
+  annotations: Annotation[]
+  labels: Label[]
+}) {
+  const annotatedItemIds = useMemo(
+    () =>
+      new Set(
+        annotations
+          .map((annotation) => annotation.item_id ?? annotation.itemId)
+          .filter(Boolean) as string[]
+      ),
+    [annotations]
+  )
+
+  // "Continue labeling" resumes where the user left off (the remembered item),
+  // falling back to the first still-unlabeled item, then the first item.
+  const nextItemId = useMemo(() => {
+    const saved = getLastItem(projectId)
+    if (saved) return saved
+    const next = items.find((item) => !annotatedItemIds.has(item.id))
+    return (next ?? items[0])?.id
+  }, [items, annotatedItemIds, projectId])
+
+  // Annotation count per class, for the distribution view.
+  const labelCounts = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const annotation of annotations) {
+      const id = annotation.label_id ?? annotation.labelId
+      if (id) counts.set(id, (counts.get(id) ?? 0) + 1)
+    }
+    return counts
+  }, [annotations])
+
+  const maxLabelCount = useMemo(
+    () => Math.max(1, ...labels.map((label) => labelCounts.get(label.id) ?? 0)),
+    [labels, labelCounts]
+  )
+
+  return { annotatedItemIds, nextItemId, labelCounts, maxLabelCount }
+}
+
+/** Call-to-action wording for the primary labeling button. */
+export function labelingCtaLabel(progress: number, annotatedItems: number): string {
+  if (progress >= 100) return "Review images"
+  return annotatedItems > 0 ? "Continue labeling" : "Start labeling"
+}

--- a/apps/studio/src/features/projects/routes/project-create.tsx
+++ b/apps/studio/src/features/projects/routes/project-create.tsx
@@ -1,105 +1,56 @@
-import { memo, useCallback, useEffect, useMemo, useState } from "react"
-import { ChevronRight, Clapperboard, Clock, Film, FileText, ImageIcon, Table2, X } from "lucide-react"
-import { Button } from "@/shared/ui/button"
-import { Input } from "@/shared/ui/input"
-import { Label } from "@/shared/ui/label"
-import { Textarea } from "@/shared/ui/textarea"
-import { Badge } from "@/shared/ui/badge"
+import { memo, useEffect, useMemo, useState } from "react"
 import { Alert, AlertDescription } from "@/shared/ui/alert"
+import { Button } from "@/shared/ui/button"
 import { Spinner } from "@/shared/ui/spinner"
-import { ImageGrid } from "@/features/projects/components/image-upload"
-import { LabelingInterfaceEditor } from "@/features/projects/components/labeling-interface-editor"
-import { TemplateIllustration } from "@/features/projects/components/template-illustrations"
-import { FileDropZone } from "@/features/projects/components/file-drop-zone"
-import { useFileDrop } from "@/features/projects/hooks/use-file-drop"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/shared/ui/tabs"
+import { ProjectStep } from "@/features/projects/components/create/project-step"
+import { LabelingStep } from "@/features/projects/components/create/labeling-step"
+import { DataStep } from "@/features/projects/components/create/data-step"
 import { useProjectCreateViewModel } from "@/features/projects/model/project-create-viewmodel"
+import { deriveConfigInfo } from "@/features/projects/model/config-info"
 import {
   LABELING_TEMPLATES,
   TEMPLATE_CATEGORY_ORDER,
-  DATA_KIND_LABELS,
   type DataKind,
   type LabelingTemplate,
 } from "@/shared/lib/label-config/labeling-templates"
-import {
-  descriptorForKind,
-  type ModalityDescriptor,
-} from "@/features/projects/model/modality-registry"
-import {
-  describeImport,
-  type ImportGuide,
-} from "@/features/projects/model/import-guide"
-import { parseLabelConfig } from "@/shared/lib/label-config/parse"
+import { descriptorForKind } from "@/features/projects/model/modality-registry"
 import { configStringForTemplate } from "@/shared/lib/label-config/generate"
-import { inferModalityTask, isMultiTextJudgement } from "@/shared/lib/label-config/infer"
-import type { LabelConfig } from "@/shared/lib/label-config/types"
-import { cn } from "@/shared/lib/utils"
-
-type ViewModel = ReturnType<typeof useProjectCreateViewModel>
+import { inferModalityTask } from "@/shared/lib/label-config/infer"
 
 // Template-first flow: name the project, choose what you're labeling (which
 // fixes the data kind), then import data matching that template.
-const TABS = ["Project Name", "Labeling Setup", "Data Import"] as const
-const CUSTOM_TEMPLATE_ID = "custom"
-const MAIN_CATEGORIES = TEMPLATE_CATEGORY_ORDER.filter((c) => c !== "Custom")
+const STEPS = [
+  { value: "name", label: "Project Name" },
+  { value: "labeling", label: "Labeling Setup" },
+  { value: "data", label: "Data Import" },
+] as const
 
-interface ConfigInfo {
-  ok: boolean
-  config: LabelConfig | null
-  dataKind: DataKind
-  error: string | null
-}
+const CUSTOM_TEMPLATE_ID = "custom"
+const MAIN_CATEGORIES = TEMPLATE_CATEGORY_ORDER.filter(
+  (category) => category !== "Custom"
+)
 
 export const ProjectCreate = memo(() => {
   const viewModel = useProjectCreateViewModel()
 
-  const [tab, setTab] = useState(0)
+  const [step, setStep] = useState<string>(STEPS[0].value)
   const [templateId, setTemplateId] = useState("object-detection")
   const [category, setCategory] = useState("Computer Vision")
 
   const selectedTemplate = useMemo(
-    () => LABELING_TEMPLATES.find((t) => t.id === templateId),
+    () => LABELING_TEMPLATES.find((template) => template.id === templateId),
     [templateId]
   )
   const customTemplate = useMemo(
-    () => LABELING_TEMPLATES.find((t) => t.id === CUSTOM_TEMPLATE_ID),
+    () => LABELING_TEMPLATES.find((template) => template.id === CUSTOM_TEMPLATE_ID),
     []
   )
 
-  // The labeling config is the single source of truth for validity, the data
-  // kind to import, and the visual editor + preview.
-  const configInfo = useMemo<ConfigInfo>(() => {
-    try {
-      const parsed = parseLabelConfig(viewModel.labelConfig)
-      // The primary object tag maps to a data kind. For image/text/audio/video
-      // the tag IS the kind; the `table` object maps to the `tabular` kind.
-      const primary = parsed.objects.find((object) =>
-        ["image", "text", "audio", "video", "table"].includes(object.tag)
-      )
-      // Multi-field LLM-eval tasks (prompt + responses) and explicit `table`
-      // objects are one-row-per-task, so they import via the spreadsheet path
-      // (each row carries its fields inline). Everything else maps the primary
-      // object tag straight to its data kind.
-      const dataKind: DataKind = isMultiTextJudgement(parsed)
-        ? "tabular"
-        : primary?.tag === "table"
-          ? "tabular"
-          : ((primary?.tag as DataKind) ?? "image")
-      const ok = parsed.objects.length > 0 && parsed.controls.length > 0
-      return {
-        ok,
-        config: parsed,
-        dataKind,
-        error: ok ? null : "Add a data object and at least one control.",
-      }
-    } catch (error) {
-      return {
-        ok: false,
-        config: null,
-        dataKind: "image",
-        error: error instanceof Error ? error.message : "Invalid config",
-      }
-    }
-  }, [viewModel.labelConfig])
+  const configInfo = useMemo(
+    () => deriveConfigInfo(viewModel.labelConfig),
+    [viewModel.labelConfig]
+  )
 
   // Selecting a template just loads its config; the config then drives
   // everything (modality, task, classes, data kind) — see the effect below.
@@ -153,38 +104,30 @@ export const ProjectCreate = memo(() => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [effectiveDataKind])
 
-  // One entry per tab, in tab order (name · template · data). `hasItems` is false
+  // One entry per step, in order (name · template · data). `hasItems` is false
   // when the kind has no descriptor, so it also gates out roadmap templates.
-  const tabValid = [
-    viewModel.name.trim().length > 0,
-    selectedTemplate?.status === "available" && configInfo.ok,
-    hasItems,
-  ]
-  const canSave = tabValid.every(Boolean)
+  const canSave =
+    viewModel.name.trim().length > 0 &&
+    selectedTemplate?.status === "available" &&
+    configInfo.ok &&
+    hasItems
 
   return (
-    <div className="-m-6 flex h-[calc(100%+3rem)] flex-col overflow-hidden bg-background text-foreground">
-      {/* Top bar: title · tabs · cancel/save */}
+    <Tabs
+      value={step}
+      onValueChange={setStep}
+      className="-m-6 flex h-[calc(100%+3rem)] flex-col gap-0 overflow-hidden bg-background text-foreground"
+    >
       <header className="flex items-center gap-4 border-b border-border px-6 py-3">
         <h1 className="text-xl font-bold">Create Project</h1>
         <div className="flex flex-1 justify-center">
-          <div className="inline-flex items-center gap-1 rounded-lg bg-muted p-1">
-            {TABS.map((label, index) => (
-              <button
-                key={label}
-                type="button"
-                onClick={() => setTab(index)}
-                className={cn(
-                  "rounded-md px-4 py-1.5 text-sm font-medium transition-colors",
-                  index === tab
-                    ? "bg-background text-foreground shadow-sm"
-                    : "text-muted-foreground hover:text-foreground"
-                )}
-              >
-                {label}
-              </button>
+          <TabsList>
+            {STEPS.map((entry) => (
+              <TabsTrigger key={entry.value} value={entry.value}>
+                {entry.label}
+              </TabsTrigger>
             ))}
-          </div>
+          </TabsList>
         </div>
         <div className="flex items-center gap-2">
           <Button
@@ -197,7 +140,6 @@ export const ProjectCreate = memo(() => {
           <Button
             onClick={() => void viewModel.createProject(descriptor)}
             disabled={!canSave || viewModel.isCreating}
-            className="gap-2"
           >
             {viewModel.isCreating && <Spinner />}
             Save
@@ -206,35 +148,42 @@ export const ProjectCreate = memo(() => {
       </header>
 
       <div className="min-h-0 flex-1 overflow-hidden">
-        {tab === 0 && (
-          <div className="h-full overflow-y-auto p-6">
-            <ProjectStep viewModel={viewModel} />
-          </div>
-        )}
+        <TabsContent value="name" className="h-full overflow-y-auto p-6">
+          <ProjectStep
+            name={viewModel.name}
+            description={viewModel.description}
+            onNameChange={viewModel.setName}
+            onDescriptionChange={viewModel.setDescription}
+          />
+        </TabsContent>
 
-        {tab === 1 && (
+        <TabsContent value="labeling" className="h-full">
           <LabelingStep
+            categories={MAIN_CATEGORIES}
             category={category}
             onSelectCategory={setCategory}
             templateId={templateId}
             selectedTemplate={selectedTemplate}
             customTemplate={customTemplate}
             configInfo={configInfo}
-            viewModel={viewModel}
+            labelConfig={viewModel.labelConfig}
+            onLabelConfigChange={viewModel.setLabelConfig}
             onSelectTemplate={selectTemplate}
+            onSelectCustom={(template) => {
+              setCategory("Custom")
+              selectTemplate(template)
+            }}
           />
-        )}
+        </TabsContent>
 
-        {tab === 2 && (
-          <div className="h-full overflow-y-auto p-6">
-            <DataStep
-              viewModel={viewModel}
-              selectedTemplate={selectedTemplate}
-              descriptor={descriptor}
-              config={configInfo.config}
-            />
-          </div>
-        )}
+        <TabsContent value="data" className="h-full overflow-y-auto p-6">
+          <DataStep
+            viewModel={viewModel}
+            selectedTemplate={selectedTemplate}
+            descriptor={descriptor}
+            config={configInfo.config}
+          />
+        </TabsContent>
       </div>
 
       {viewModel.error ? (
@@ -248,423 +197,8 @@ export const ProjectCreate = memo(() => {
           </Alert>
         </div>
       ) : null}
-    </div>
+    </Tabs>
   )
 })
 
 ProjectCreate.displayName = "ProjectCreate"
-
-// ── Tab: Project Name ────────────────────────────────────────────────────────
-const ProjectStep = memo(({ viewModel }: { viewModel: ViewModel }) => (
-  <div className="mx-auto flex max-w-xl flex-col gap-4">
-    <div className="space-y-2">
-      <Label htmlFor="project-name">Project name</Label>
-      <Input
-        id="project-name"
-        value={viewModel.name}
-        onChange={(event) => viewModel.setName(event.target.value)}
-        placeholder="My dataset"
-        autoFocus
-      />
-    </div>
-    <div className="space-y-2">
-      <Label htmlFor="project-description">
-        Description <span className="text-muted-foreground">(optional)</span>
-      </Label>
-      <Textarea
-        id="project-description"
-        value={viewModel.description}
-        onChange={(event) => viewModel.setDescription(event.target.value)}
-        placeholder="What is this dataset about?"
-        rows={3}
-      />
-    </div>
-  </div>
-))
-
-ProjectStep.displayName = "ProjectStep"
-
-// ── Tab: Labeling Setup (category sidebar + template grid + interface) ────────
-const LabelingStep = memo(
-  ({
-    category,
-    onSelectCategory,
-    templateId,
-    selectedTemplate,
-    customTemplate,
-    configInfo,
-    viewModel,
-    onSelectTemplate,
-  }: {
-    category: string
-    onSelectCategory: (category: string) => void
-    templateId: string
-    selectedTemplate?: LabelingTemplate
-    customTemplate?: LabelingTemplate
-    configInfo: ConfigInfo
-    viewModel: ViewModel
-    onSelectTemplate: (template: LabelingTemplate) => void
-  }) => {
-    const templates = useMemo(
-      () => LABELING_TEMPLATES.filter((t) => t.category === category),
-      [category]
-    )
-    return (
-      <div className="flex h-full">
-        {/* Category sidebar */}
-        <nav className="w-56 shrink-0 overflow-y-auto border-r border-border py-2">
-          {MAIN_CATEGORIES.map((cat) => (
-            <button
-              key={cat}
-              type="button"
-              onClick={() => onSelectCategory(cat)}
-              className={cn(
-                "flex w-full items-center justify-between gap-2 px-4 py-2 text-left text-sm transition-colors",
-                cat === category
-                  ? "bg-muted font-medium text-foreground"
-                  : "text-muted-foreground hover:bg-muted/50 hover:text-foreground"
-              )}
-            >
-              <span className="truncate">{cat}</span>
-              <ChevronRight className="size-4 shrink-0 opacity-60" />
-            </button>
-          ))}
-          {customTemplate && (
-            <button
-              type="button"
-              onClick={() => {
-                onSelectCategory("Custom")
-                onSelectTemplate(customTemplate)
-              }}
-              className={cn(
-                "mt-1 w-full border-t border-border px-4 py-2 text-left text-sm font-medium text-primary transition-colors hover:bg-muted/50",
-                category === "Custom" && "bg-muted"
-              )}
-            >
-              Custom template
-            </button>
-          )}
-        </nav>
-
-        {/* Template grid + interface editor */}
-        <div className="min-w-0 flex-1 overflow-y-auto p-5">
-          <div className="grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-4">
-            {templates.map((template) => (
-              <TemplateCard
-                key={template.id}
-                template={template}
-                selected={template.id === templateId}
-                onSelect={onSelectTemplate}
-              />
-            ))}
-          </div>
-
-          {selectedTemplate && (
-            <div className="mt-6 border-t border-border pt-5">
-              <p className="mb-3 text-sm font-semibold">
-                {selectedTemplate.label}{" "}
-                <span className="font-normal text-muted-foreground">
-                  · configure the interface
-                </span>
-              </p>
-              <LabelingInterfaceEditor
-                value={viewModel.labelConfig}
-                onChange={viewModel.setLabelConfig}
-                config={configInfo.config}
-                error={configInfo.error}
-              />
-            </div>
-          )}
-        </div>
-      </div>
-    )
-  }
-)
-
-LabelingStep.displayName = "LabelingStep"
-
-// A template card with an icon "thumbnail" header (Label Studio gallery style).
-const TemplateCard = memo(
-  ({
-    template,
-    selected,
-    onSelect,
-  }: {
-    template: LabelingTemplate
-    selected: boolean
-    onSelect: (template: LabelingTemplate) => void
-  }) => {
-    const available = template.status === "available"
-    return (
-      <button
-        type="button"
-        disabled={!available}
-        onClick={() => onSelect(template)}
-        className={cn(
-          "group flex flex-col overflow-hidden rounded-lg border text-left transition-all",
-          selected
-            ? "border-primary ring-2 ring-primary"
-            : available
-              ? "border-border hover:border-primary/50 hover:shadow-sm"
-              : "cursor-not-allowed border-dashed border-border opacity-60"
-        )}
-      >
-        <div className="aspect-[4/3] overflow-hidden bg-muted">
-          {template.image ? (
-            <img
-              src={template.image}
-              alt={template.label}
-              loading="lazy"
-              className="h-full w-full object-cover"
-            />
-          ) : (
-            <TemplateIllustration template={template} className="h-full w-full" />
-          )}
-        </div>
-        <div className="flex items-start gap-1.5 p-3">
-          <p className="min-w-0 flex-1 text-sm font-medium leading-snug">
-            {template.label}
-          </p>
-          {!available && (
-            <Badge
-              variant="secondary"
-              className="gap-1 text-warning"
-            >
-              <Clock className="size-3" />
-              Soon
-            </Badge>
-          )}
-        </div>
-      </button>
-    )
-  }
-)
-
-TemplateCard.displayName = "TemplateCard"
-
-// ── Tab: Data Import (drop zone) ─────────────────────────────────────────────
-// Tells the user exactly what to import for the chosen template — including the
-// spreadsheet columns LLM-eval / tabular templates expect (derived from config).
-const ImportGuideCard = memo(
-  ({
-    template,
-    guide,
-  }: {
-    template?: LabelingTemplate
-    guide: ImportGuide
-  }) => {
-    const Icon = template?.icon
-    return (
-      <div className="rounded-lg border border-border bg-card p-4">
-        <div className="flex items-center gap-2">
-          {Icon && <Icon className="size-4 shrink-0 text-primary" />}
-          <p className="text-sm font-semibold">{guide.title}</p>
-        </div>
-        {template && (
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            for {template.label}
-          </p>
-        )}
-        <p className="mt-2 text-sm text-muted-foreground">{guide.detail}</p>
-
-        {guide.columns.length > 0 && (
-          <div className="mt-3 border-t border-border pt-3">
-            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              Expected columns
-            </p>
-            <div className="mt-1.5 flex flex-wrap gap-1.5">
-              {guide.columns.map((column) => (
-                <span
-                  key={column.key}
-                  className="inline-flex items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-0.5 text-xs"
-                >
-                  <code className="font-mono text-foreground">{column.key}</code>
-                  {column.label !== column.key && (
-                    <span className="text-muted-foreground">{column.label}</span>
-                  )}
-                </span>
-              ))}
-            </div>
-            <p className="mt-1.5 text-xs text-muted-foreground">
-              Your file's header row should include these columns (extra columns
-              are ignored). To use different names, edit the field bindings in
-              Labeling Setup.
-            </p>
-          </div>
-        )}
-
-        {guide.example && (
-          <div className="mt-3 border-t border-border pt-3">
-            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              Example
-            </p>
-            <pre className="mt-1.5 overflow-x-auto rounded-md border border-border bg-muted/50 p-3 text-xs leading-relaxed text-foreground">
-              <code>{guide.example}</code>
-            </pre>
-          </div>
-        )}
-      </div>
-    )
-  }
-)
-
-ImportGuideCard.displayName = "ImportGuideCard"
-
-const DataStep = memo(
-  ({
-    viewModel,
-    selectedTemplate,
-    descriptor,
-    config,
-  }: {
-    viewModel: ViewModel
-    selectedTemplate?: LabelingTemplate
-    descriptor?: ModalityDescriptor
-    config: LabelConfig | null
-  }) => {
-    const isImage = descriptor?.kind === "image"
-    const isFiles = descriptor?.importMode === "files"
-    const isSpreadsheet = descriptor?.importMode === "spreadsheet"
-
-    const handleDrop = useCallback(
-      (paths: string[]) => {
-        if (!descriptor) return
-        const picked = paths.filter(descriptor.accepts)
-        if (descriptor.kind === "image") void viewModel.addImagePaths(picked)
-        else if (descriptor.importMode === "spreadsheet")
-          void viewModel.addSpreadsheetPaths(picked)
-        else if (descriptor.importMode === "files")
-          void viewModel.addDocumentPaths(picked, descriptor.grantScope)
-      },
-      [viewModel, descriptor]
-    )
-    const isOver = useFileDrop(handleDrop, isImage || isFiles || isSpreadsheet)
-
-    // Deferred-import kinds (video): clips are imported inside the studio editor.
-    if (descriptor?.importMode === "none") {
-      return (
-        <div className="mx-auto max-w-2xl">
-          <Alert>
-            <Film className="size-4" />
-            <AlertDescription>
-              Create the project, then import and process your video clips in the
-              studio — it extracts frames, detects scene cuts, and tracks objects
-              across time.
-            </AlertDescription>
-          </Alert>
-        </div>
-      )
-    }
-
-    // Unsupported kind: a roadmap template with no registered descriptor.
-    if (!descriptor) {
-      return (
-        <div className="mx-auto max-w-2xl">
-          <Alert>
-            <Clock className="size-4" />
-            <AlertDescription>
-              {selectedTemplate
-                ? `${DATA_KIND_LABELS[selectedTemplate.dataKind]} import isn't available yet — this template is on the roadmap.`
-                : "Pick a template first."}
-            </AlertDescription>
-          </Alert>
-        </div>
-      )
-    }
-
-    const guide = describeImport(descriptor, config)
-
-    return (
-      <div className="mx-auto flex max-w-2xl flex-col gap-4">
-        <ImportGuideCard template={selectedTemplate} guide={guide} />
-
-        <FileDropZone
-          isOver={isOver}
-          busy={viewModel.isScanning}
-          onBrowse={() => void viewModel.openImport(descriptor)}
-          formats={guide.formats}
-        />
-
-        {isImage && viewModel.folderPath && (
-          <p className="truncate text-xs text-muted-foreground">
-            {viewModel.folderPath}
-          </p>
-        )}
-
-        {isImage && viewModel.images.length > 0 && (
-          <div className="flex flex-col gap-3">
-            <div className="flex items-center gap-2">
-              <ImageIcon className="size-5 text-primary" />
-              <span className="font-semibold">Selected images</span>
-              <Badge variant="secondary">
-                {viewModel.images.length} file
-                {viewModel.images.length !== 1 ? "s" : ""}
-              </Badge>
-            </div>
-            <ImageGrid images={viewModel.images} onRemove={viewModel.removeImage} />
-          </div>
-        )}
-
-        {(isFiles || isSpreadsheet) && viewModel.documents.length > 0 && (
-          <div className="flex flex-col gap-3">
-            <div className="flex items-center gap-2">
-              {descriptor.kind === "video" ? (
-                <Clapperboard className="size-5 text-primary" />
-              ) : isSpreadsheet ? (
-                <Table2 className="size-5 text-primary" />
-              ) : (
-                <FileText className="size-5 text-primary" />
-              )}
-              <span className="font-semibold">
-                {descriptor.kind === "audio"
-                  ? "Selected clips"
-                  : descriptor.kind === "video"
-                    ? "Selected videos"
-                    : isSpreadsheet
-                      ? "Imported rows"
-                      : "Selected documents"}
-              </span>
-              <Badge variant="secondary">
-                {viewModel.documents.length}{" "}
-                {isSpreadsheet ? "row" : "file"}
-                {viewModel.documents.length !== 1 ? "s" : ""}
-              </Badge>
-            </div>
-            <ul className="max-h-72 divide-y divide-border overflow-y-auto rounded-lg border border-border">
-              {viewModel.documents.slice(0, 200).map((doc, index) => (
-                <li
-                  key={doc.id}
-                  className="flex items-center gap-2 px-3 py-2 text-sm"
-                >
-                  {isSpreadsheet ? (
-                    <Table2 className="size-4 shrink-0 text-muted-foreground" />
-                  ) : (
-                    <FileText className="size-4 shrink-0 text-muted-foreground" />
-                  )}
-                  <span className="min-w-0 flex-1 truncate" title={doc.path || doc.name}>
-                    {doc.name}
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => viewModel.removeDocument(index)}
-                    className="rounded-full p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
-                    aria-label={`Remove ${doc.name}`}
-                  >
-                    <X className="size-3.5" />
-                  </button>
-                </li>
-              ))}
-            </ul>
-            {isSpreadsheet && viewModel.documents.length > 200 && (
-              <p className="text-xs text-muted-foreground">
-                Showing the first 200 of {viewModel.documents.length} rows.
-              </p>
-            )}
-          </div>
-        )}
-      </div>
-    )
-  }
-)
-
-DataStep.displayName = "DataStep"

--- a/apps/studio/src/features/projects/routes/project-detail.tsx
+++ b/apps/studio/src/features/projects/routes/project-detail.tsx
@@ -1,67 +1,35 @@
-import { memo, useMemo } from "react"
-import {
-  ArrowLeft,
-  ImageIcon,
-  FileText,
-  Tag,
-  Calendar,
-  RefreshCw,
-  Edit,
-  Plus,
-  Trash2,
-  Upload,
-  FolderOpen,
-  Play,
-  Layers,
-  BarChart3,
-  CheckCircle2,
-  CloudUpload,
-  CloudDownload,
-  Brain,
-  Clapperboard,
-  Settings,
-  X,
-} from "lucide-react"
-import { Button } from "@/shared/ui/button"
+import { memo } from "react"
+import { useNavigate, useParams } from "react-router-dom"
+import { Brain, ImageIcon, Settings, Tag, Upload } from "lucide-react"
+import { toast } from "sonner"
 import { Badge } from "@/shared/ui/badge"
-import {
-  Card,
-  CardAction,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/shared/ui/card"
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/shared/ui/tabs"
-import { Progress } from "@/shared/ui/progress"
-import { Spinner } from "@/shared/ui/spinner"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/shared/ui/tabs"
 import { ImageTable } from "@/features/projects/components/image-table"
-import { TrainingMonitor } from "@/shared/components/training/training-monitor"
-import { ModelFlywheel } from "@/features/projects/components/model-flywheel"
-import { DatasetImportCard } from "@/features/projects/components/dataset-import-card"
-import type { DatasetImportFormat } from "@/shared/types/ai-runtime"
 import { EditProjectModal } from "@/features/projects/components/edit-project-modal"
 import { AddLabelModal } from "@/features/projects/components/add-label-modal"
-import { ImageGrid } from "@/features/projects/components/image-upload"
-import { useProjectDetailViewModel } from "@/features/projects/model/project-detail-viewmodel"
-import { descriptorForKind } from "@/features/projects/model/modality-registry"
-import type { DataKind } from "@/shared/lib/label-config/labeling-templates"
-import { useProjectCloudSync } from "@/features/projects/hooks/use-project-cloud-sync"
 import { ProjectSettingsTab } from "@/features/projects/components/project-settings-tab"
-import { useParams, useNavigate } from "react-router-dom"
-import { getLastItem } from "@/shared/lib/last-item"
-import { toast } from "sonner"
-import { cn } from "@/shared/lib/utils"
+import { AddDataTab } from "@/features/projects/components/detail/add-data-tab"
+import { ClassesTab } from "@/features/projects/components/detail/classes-tab"
+import { LabelingProgressCard } from "@/features/projects/components/detail/labeling-progress-card"
+import { ModelTab } from "@/features/projects/components/detail/model-tab"
+import { ProjectDetailHeader } from "@/features/projects/components/detail/project-detail-header"
+import {
+  ProjectDetailError,
+  ProjectDetailLoading,
+} from "@/features/projects/components/detail/project-detail-status"
+import { ProjectStatsGrid } from "@/features/projects/components/detail/project-stats-grid"
+import { ProjectToolbar } from "@/features/projects/components/detail/project-toolbar"
+import { TabHeading } from "@/features/projects/components/detail/tab-heading"
+import { useProjectDetailViewModel } from "@/features/projects/model/project-detail-viewmodel"
+import {
+  labelingCtaLabel,
+  useProjectDetailDerivations,
+} from "@/features/projects/model/use-project-detail-derivations"
+import { useProjectCloudSync } from "@/features/projects/hooks/use-project-cloud-sync"
+import type { DataKind } from "@/shared/lib/label-config/labeling-templates"
+import type { DatasetImportFormat } from "@/shared/types/ai-runtime"
 
-const formatDate = (date: Date | string | undefined) => {
-  if (!date) return "Unknown"
-  const dateObj = typeof date === "string" ? new Date(date) : date
-  if (isNaN(dateObj.getTime())) return "Unknown"
-  return new Intl.DateTimeFormat("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  }).format(dateObj)
-}
+type DetailTab = "images" | "upload" | "labels" | "training" | "settings"
 
 const ProjectDetails = memo(() => {
   const { projectId } = useParams<{ projectId: string }>()
@@ -72,273 +40,87 @@ const ProjectDetails = memo(() => {
     viewModel.refreshData,
     viewModel.project?.config?.storage
   )
-  const s = viewModel.projectStats
 
-  // First image still needing annotation (so "Continue Labeling" resumes work).
-  const annotatedItemIds = useMemo(
-    () =>
-      new Set(
-        viewModel.annotations
-          .map((a) => a.item_id ?? a.itemId)
-          .filter(Boolean) as string[]
-      ),
-    [viewModel.annotations]
-  )
+  const stats = viewModel.projectStats
+  const { nextItemId, labelCounts, maxLabelCount } = useProjectDetailDerivations({
+    projectId,
+    items: viewModel.images,
+    annotations: viewModel.annotations,
+    labels: viewModel.labels,
+  })
 
-  // "Continue labeling" resumes where the user left off (the remembered item),
-  // falling back to the first still-unlabeled image, then the first image.
-  const nextImageId = useMemo(() => {
-    const saved = getLastItem(projectId)
-    if (saved) return saved
-    const next = viewModel.images.find((img) => !annotatedItemIds.has(img.id))
-    return (next ?? viewModel.images[0])?.id
-  }, [viewModel.images, annotatedItemIds, projectId])
-
-  // Annotation count per class, for the distribution view.
-  const labelCounts = useMemo(() => {
-    const counts = new Map<string, number>()
-    for (const a of viewModel.annotations) {
-      const id = a.label_id ?? a.labelId
-      if (id) counts.set(id, (counts.get(id) ?? 0) + 1)
-    }
-    return counts
-  }, [viewModel.annotations])
-
-  const maxLabelCount = useMemo(
-    () =>
-      Math.max(1, ...viewModel.labels.map((l) => labelCounts.get(l.id) ?? 0)),
-    [viewModel.labels, labelCounts]
-  )
-
-  const labelingCta =
-    s.progress >= 100
-      ? "Review images"
-      : s.annotatedImages > 0
-        ? "Continue labeling"
-        : "Start labeling"
+  const goToNextItem = () => {
+    if (nextItemId) viewModel.navigateToItem(nextItemId)
+  }
 
   // Import an annotated dataset folder (format auto-detected or forced) and
   // report what landed.
   const handleImportDataset = async (format: DatasetImportFormat = "auto") => {
     try {
-      const res = await viewModel.importDataset(format)
-      if (!res) return
+      const result = await viewModel.importDataset(format)
+      if (!result) return
       toast.success(
-        `Imported ${res.itemCount} images · ${res.annotationCount} boxes · ${res.createdClassCount} new classes (${res.format.toUpperCase()})`,
+        `Imported ${result.itemCount} images · ${result.annotationCount} boxes · ${result.createdClassCount} new classes (${result.format.toUpperCase()})`,
         {
-          description: res.warnings.length
-            ? `${res.warnings.length} item(s) were skipped — open the console for details.`
+          description: result.warnings.length
+            ? `${result.warnings.length} item(s) were skipped — open the console for details.`
             : "Switch to the Images tab to keep labeling, or Model to train on them.",
         }
       )
-      if (res.warnings.length) {
-        console.warn("Dataset import warnings:", res.warnings)
+      if (result.warnings.length) {
+        console.warn("Dataset import warnings:", result.warnings)
       }
-    } catch (e) {
+    } catch (error) {
       toast.error("Import failed", {
-        description: e instanceof Error ? e.message : String(e),
+        description: error instanceof Error ? error.message : String(error),
       })
     }
   }
 
-  const stats = [
-    { label: "Images", value: s.totalItems, icon: ImageIcon },
-    {
-      label: "Annotated",
-      value: `${s.annotatedImages} / ${s.totalItems}`,
-      icon: CheckCircle2,
-    },
-    { label: "Annotations", value: s.totalAnnotations, icon: BarChart3 },
-    { label: "Classes", value: s.totalLabels, icon: Layers },
-  ]
-
   return (
     <div className="mx-auto flex max-w-6xl flex-col gap-6">
-      {/* Header */}
-      <div className="flex flex-col gap-4">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={viewModel.navigateBack}
-          className="-ml-2 w-fit gap-1.5 text-muted-foreground"
-        >
-          <ArrowLeft className="size-4" />
-          Projects
-        </Button>
-
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div className="min-w-0 space-y-1">
-            <div className="flex flex-wrap items-center gap-2">
-              <h1 className="truncate text-2xl font-bold text-foreground">
-                {viewModel.projectName}
-              </h1>
-              {viewModel.project?.type && (
-                <Badge variant="secondary" className="capitalize">
-                  {viewModel.project.type}
-                </Badge>
-              )}
-              {viewModel.project?.status && (
-                <Badge variant="outline" className="capitalize">
-                  {viewModel.project.status}
-                </Badge>
-              )}
-            </div>
-            <p className="max-w-2xl text-sm text-muted-foreground">
-              {viewModel.project?.description?.trim() ||
-                "No description yet — edit the project to add one."}
-            </p>
-            <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              <Calendar className="size-3.5" />
-              Created {formatDate(viewModel.project?.createdAt)}
-            </p>
-          </div>
-
-          <div className="flex flex-wrap items-center gap-2">
-            {viewModel.project?.modality === "video" && (
-              <Button
-                size="sm"
-                onClick={viewModel.openVideoEditor}
-                className="gap-1.5"
-              >
-                <Clapperboard className="size-4" />
-                Open video editor
-              </Button>
-            )}
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={viewModel.refreshData}
-              disabled={viewModel.isLoading}
-              className="gap-1.5"
-            >
-              <RefreshCw
-                className={cn("size-4", viewModel.isLoading && "animate-spin")}
-              />
-              Refresh
-            </Button>
-            {cloudSync.activeConfig && (
-              <>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={cloudSync.pushToCloud}
-                  disabled={cloudSync.isSyncing}
-                  className="gap-1.5"
-                  title={`Upload items to ${cloudSync.activeConfig.name}`}
-                >
-                  <CloudUpload
-                    className={cn(
-                      "size-4",
-                      cloudSync.isSyncing && "animate-pulse"
-                    )}
-                  />
-                  Push
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={cloudSync.pullFromCloud}
-                  disabled={cloudSync.isSyncing}
-                  className="gap-1.5"
-                  title={`Download items from ${cloudSync.activeConfig.name}`}
-                >
-                  <CloudDownload
-                    className={cn(
-                      "size-4",
-                      cloudSync.isSyncing && "animate-pulse"
-                    )}
-                  />
-                  Pull
-                </Button>
-              </>
-            )}
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={viewModel.openEditProjectModal}
-              className="gap-1.5"
-            >
-              <Edit className="size-4" />
-              Edit
-            </Button>
-            <Button
-              size="sm"
-              onClick={() => nextImageId && viewModel.navigateToItem(nextImageId)}
-              disabled={!nextImageId}
-              className="gap-1.5"
-            >
-              <Play className="size-4" />
-              {labelingCta}
-            </Button>
-          </div>
-        </div>
-      </div>
+      <ProjectDetailHeader
+        project={viewModel.project}
+        projectName={viewModel.projectName}
+        onBack={viewModel.navigateBack}
+        actions={
+          <ProjectToolbar
+            isVideoProject={viewModel.project?.modality === "video"}
+            onOpenVideoEditor={viewModel.openVideoEditor}
+            onRefresh={viewModel.refreshData}
+            isLoading={viewModel.isLoading}
+            cloudTargetName={cloudSync.activeConfig?.name}
+            isSyncing={cloudSync.isSyncing}
+            onPush={cloudSync.pushToCloud}
+            onPull={cloudSync.pullFromCloud}
+            onEdit={viewModel.openEditProjectModal}
+            labelingCta={labelingCtaLabel(stats.progress, stats.annotatedImages)}
+            canLabel={Boolean(nextItemId)}
+            onStartLabeling={goToNextItem}
+          />
+        }
+      />
 
       {viewModel.isLoading ? (
-        <div className="flex h-64 items-center justify-center">
-          <div className="flex flex-col items-center gap-3 text-muted-foreground">
-            <Spinner className="size-6" />
-            <p className="text-sm">Loading project data…</p>
-          </div>
-        </div>
+        <ProjectDetailLoading />
       ) : viewModel.error ? (
-        <Card className="border-destructive/40">
-          <CardContent className="flex flex-col items-center gap-3 py-10 text-center">
-            <p className="font-medium text-destructive">Error loading project</p>
-            <p className="max-w-md text-sm text-muted-foreground">
-              {typeof viewModel.error === "string"
-                ? viewModel.error
-                : "An unexpected error occurred."}
-            </p>
-            <Button variant="outline" size="sm" onClick={viewModel.loadProjectData}>
-              Try again
-            </Button>
-          </CardContent>
-        </Card>
+        <ProjectDetailError
+          error={viewModel.error}
+          onRetry={viewModel.loadProjectData}
+        />
       ) : (
         <>
-          {/* Stat cards */}
-          <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
-            {stats.map((stat) => (
-              <Card key={stat.label} size="sm">
-                <CardContent className="flex items-center gap-3">
-                  <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
-                    <stat.icon className="size-4.5" />
-                  </div>
-                  <div className="min-w-0">
-                    <p className="text-xs text-muted-foreground">{stat.label}</p>
-                    <p className="truncate text-lg font-semibold tabular-nums text-foreground">
-                      {stat.value}
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
+          <ProjectStatsGrid stats={stats} />
 
-          {/* Progress */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base">Labeling progress</CardTitle>
-              <CardAction>
-                <span className="text-sm tabular-nums text-muted-foreground">
-                  {s.annotatedImages} / {s.totalItems} images · {s.progress}%
-                </span>
-              </CardAction>
-            </CardHeader>
-            <CardContent>
-              <Progress value={s.progress} />
-            </CardContent>
-          </Card>
+          <LabelingProgressCard
+            annotatedItems={stats.annotatedImages}
+            totalItems={stats.totalItems}
+            progress={stats.progress}
+          />
 
-          {/* Tabs */}
           <Tabs
             value={viewModel.activeTab}
-            onValueChange={(value) =>
-              viewModel.setActiveTab(
-                value as "images" | "upload" | "labels" | "training" | "settings"
-              )
-            }
+            onValueChange={(value) => viewModel.setActiveTab(value as DetailTab)}
             className="gap-4"
           >
             <TabsList>
@@ -358,17 +140,17 @@ const ProjectDetails = memo(() => {
                 <Brain className="size-4" />
                 Model
               </TabsTrigger>
-              <TabsTrigger value="settings" className="gap-1.5 ml-auto">
+              <TabsTrigger value="settings" className="ml-auto gap-1.5">
                 <Settings className="size-4" />
                 Settings
               </TabsTrigger>
             </TabsList>
 
             <TabsContent value="images" className="flex flex-col gap-4">
-              <div className="flex items-center justify-between">
-                <h2 className="text-lg font-semibold">Items</h2>
-                <Badge variant="secondary">{s.totalItems} total</Badge>
-              </div>
+              <TabHeading
+                title="Items"
+                actions={<Badge variant="secondary">{stats.totalItems} total</Badge>}
+              />
               <ImageTable
                 images={viewModel.images}
                 isLoading={viewModel.isItemsLoading}
@@ -388,284 +170,40 @@ const ProjectDetails = memo(() => {
             </TabsContent>
 
             <TabsContent value="labels" className="flex flex-col gap-4">
-              <div className="flex items-center justify-between">
-                <h2 className="text-lg font-semibold">Classes</h2>
-                <div className="flex items-center gap-2">
-                  <Badge variant="secondary">{s.totalLabels} total</Badge>
-                  <Button
-                    size="sm"
-                    onClick={viewModel.openAddLabelModal}
-                    className="gap-1.5"
-                  >
-                    <Plus className="size-4" />
-                    Add class
-                  </Button>
-                </div>
-              </div>
-
-              {viewModel.labels.length > 0 ? (
-                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-                  {viewModel.labels.map((label) => {
-                    const count = labelCounts.get(label.id) ?? 0
-                    const pct = Math.round((count / maxLabelCount) * 100)
-                    return (
-                      <Card key={label.id} size="sm">
-                        <CardContent className="flex flex-col gap-2.5">
-                          <div className="flex items-center gap-2">
-                            <span
-                              className="size-3 shrink-0 rounded-full ring-1 ring-foreground/10"
-                              style={{ backgroundColor: label.color }}
-                            />
-                            <span className="min-w-0 flex-1 truncate font-medium">
-                              {label.name}
-                            </span>
-                            <Badge variant="secondary" className="tabular-nums">
-                              {count}
-                            </Badge>
-                            <Button
-                              variant="ghost"
-                              size="icon-sm"
-                              onClick={() => viewModel.deleteLabel(label.id)}
-                              disabled={viewModel.isCreatingLabel}
-                              className="text-muted-foreground hover:text-destructive"
-                              aria-label={`Delete ${label.name}`}
-                            >
-                              <Trash2 className="size-4" />
-                            </Button>
-                          </div>
-                          <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
-                            <div
-                              className="h-full rounded-full"
-                              style={{
-                                width: `${pct}%`,
-                                backgroundColor: label.color,
-                              }}
-                            />
-                          </div>
-                        </CardContent>
-                      </Card>
-                    )
-                  })}
-                </div>
-              ) : (
-                <EmptyState
-                  icon={<Tag className="size-10 text-muted-foreground" />}
-                  title="No classes yet"
-                  description="Add classes to start annotating, or they'll be created on the fly while labeling."
-                  action={
-                    <Button onClick={viewModel.openAddLabelModal} className="gap-1.5">
-                      <Plus className="size-4" />
-                      Add your first class
-                    </Button>
-                  }
-                />
-              )}
+              <ClassesTab
+                labels={viewModel.labels}
+                labelCounts={labelCounts}
+                maxLabelCount={maxLabelCount}
+                totalLabels={stats.totalLabels}
+                isMutating={viewModel.isCreatingLabel}
+                onAddClass={viewModel.openAddLabelModal}
+                onDeleteClass={viewModel.deleteLabel}
+              />
             </TabsContent>
 
             <TabsContent value="upload" className="flex flex-col gap-4">
-              <div>
-                <h2 className="text-lg font-semibold">Add data</h2>
-                <p className="max-w-2xl text-sm text-muted-foreground">
-                  Bring your media into this project, and optionally import
-                  existing annotations. Files are referenced in place — nothing is
-                  copied.
-                </p>
-              </div>
-
-              {(() => {
-                const modality = viewModel.project?.modality ?? "image"
-                const descriptor = descriptorForKind(modality as DataKind)
-                const isImageModality =
-                  !descriptor || descriptor.importMode === "folder"
-
-                const mediaCard = isImageModality ? (
-                  <div className="flex flex-col gap-3">
-                    <div className="flex items-center justify-between">
-                      <h3 className="font-medium">Add images</h3>
-                      <Badge variant="secondary">
-                        {viewModel.newImages.length} selected
-                      </Badge>
-                    </div>
-                    <Button
-                      variant="outline"
-                      className="w-full gap-2"
-                      onClick={viewModel.addImagesFromFolder}
-                      disabled={viewModel.isUploading}
-                    >
-                      {viewModel.isUploading ? (
-                        <Spinner />
-                      ) : (
-                        <FolderOpen className="size-5" />
-                      )}
-                      {viewModel.isUploading
-                        ? "Scanning folder…"
-                        : "Open image folder"}
-                    </Button>
-                    <ImageGrid
-                      images={viewModel.newImages}
-                      onRemove={viewModel.handleRemoveImage}
-                    />
-                    {viewModel.newImages.length > 0 && (
-                      <div className="flex justify-end">
-                        <Button
-                          onClick={viewModel.saveImages}
-                          disabled={viewModel.isUploading || viewModel.isSaving}
-                          className="gap-1.5"
-                        >
-                          {viewModel.isSaving ? (
-                            <Spinner />
-                          ) : (
-                            <Plus className="size-4" />
-                          )}
-                          {viewModel.isSaving
-                            ? "Saving images…"
-                            : `Save ${viewModel.newImages.length} image${
-                                viewModel.newImages.length !== 1 ? "s" : ""
-                              }`}
-                        </Button>
-                      </div>
-                    )}
-                  </div>
-                ) : (
-                  (() => {
-                    const kindLabel = descriptor.label
-                    const fileLabel = modality === "audio" ? "clips" : "files"
-                    return (
-                      <div className="flex flex-col gap-3">
-                        <div className="flex items-center justify-between">
-                          <h3 className="font-medium">
-                            Add {kindLabel.toLowerCase()} {fileLabel}
-                          </h3>
-                          <Badge variant="secondary">
-                            {viewModel.newDocuments.length} selected
-                          </Badge>
-                        </div>
-                        <Button
-                          variant="outline"
-                          className="w-full gap-2"
-                          onClick={() =>
-                            void viewModel.addDocumentFiles(descriptor.extensions)
-                          }
-                          disabled={viewModel.isUploading}
-                        >
-                          {viewModel.isUploading ? (
-                            <Spinner />
-                          ) : (
-                            <FileText className="size-5" />
-                          )}
-                          {viewModel.isUploading
-                            ? "Opening…"
-                            : `Select ${kindLabel.toLowerCase()} ${fileLabel}`}
-                        </Button>
-                        {viewModel.newDocuments.length > 0 && (
-                          <>
-                            <ul className="divide-y divide-border rounded-lg border border-border">
-                              {viewModel.newDocuments.map((doc, index) => (
-                                <li
-                                  key={doc.id}
-                                  className="flex items-center gap-2 px-3 py-2 text-sm"
-                                >
-                                  <FileText className="size-4 shrink-0 text-muted-foreground" />
-                                  <span
-                                    className="min-w-0 flex-1 truncate"
-                                    title={doc.path}
-                                  >
-                                    {doc.name}
-                                  </span>
-                                  <button
-                                    type="button"
-                                    onClick={() =>
-                                      viewModel.handleRemoveDocument(index)
-                                    }
-                                    className="rounded-full p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
-                                    aria-label={`Remove ${doc.name}`}
-                                  >
-                                    <X className="size-3.5" />
-                                  </button>
-                                </li>
-                              ))}
-                            </ul>
-                            <div className="flex justify-end">
-                              <Button
-                                onClick={() => void viewModel.saveDocuments()}
-                                disabled={
-                                  viewModel.isUploading || viewModel.isSaving
-                                }
-                                className="gap-1.5"
-                              >
-                                {viewModel.isSaving ? (
-                                  <Spinner />
-                                ) : (
-                                  <Plus className="size-4" />
-                                )}
-                                {viewModel.isSaving
-                                  ? `Saving ${fileLabel}…`
-                                  : `Save ${viewModel.newDocuments.length} ${fileLabel}`}
-                              </Button>
-                            </div>
-                          </>
-                        )}
-                      </div>
-                    )
-                  })()
-                )
-
-                return (
-                  <div className="flex flex-col gap-4">
-                    {mediaCard}
-                    {isImageModality && (
-                      <DatasetImportCard
-                        isImporting={viewModel.isImporting}
-                        onImport={handleImportDataset}
-                      />
-                    )}
-                  </div>
-                )
-              })()}
+              <AddDataTab
+                viewModel={viewModel}
+                modality={(viewModel.project?.modality ?? "image") as DataKind}
+                onImportDataset={handleImportDataset}
+              />
             </TabsContent>
 
             <TabsContent value="training" className="flex flex-col gap-4">
-              <div className="flex flex-wrap items-start justify-between gap-3">
-                <div>
-                  <h2 className="text-lg font-semibold">Project model</h2>
-                  <p className="max-w-2xl text-sm text-muted-foreground">
-                    This project trains its own model from your labels. Label a
-                    few → train → auto-label → correct → repeat; each cycle
-                    improves the model and the latest version pre-labels the rest.
-                  </p>
-                </div>
-                <Button
-                  onClick={() => navigate(`/projects/train/${projectId}`)}
-                  className="gap-1.5"
-                >
-                  <Brain className="size-4" />
-                  Train new version
-                </Button>
-              </div>
-              <ModelFlywheel
+              <ModelTab
                 projectId={projectId}
-                annotatedImages={s.annotatedImages}
-                totalItems={s.totalItems}
-                onContinueLabeling={() =>
-                  nextImageId && viewModel.navigateToItem(nextImageId)
-                }
-              />
-              <TrainingMonitor
-                projectId={projectId}
-                onUseForLabeling={() =>
-                  nextImageId && viewModel.navigateToItem(nextImageId)
-                }
+                annotatedItems={stats.annotatedImages}
+                totalItems={stats.totalItems}
+                onTrain={() => navigate(`/projects/train/${projectId}`)}
+                onContinueLabeling={goToNextItem}
               />
             </TabsContent>
 
             <TabsContent value="settings" className="flex flex-col gap-4">
-              <div>
-                <h2 className="text-lg font-semibold">Project settings</h2>
-                <p className="max-w-2xl text-sm text-muted-foreground">
-                  Per-project configuration — labeling behavior, export
-                  defaults, and AI preferences that apply only to this dataset.
-                </p>
-              </div>
+              <TabHeading
+                title="Project settings"
+                description="Per-project configuration — labeling behavior, export defaults, and AI preferences that apply only to this dataset."
+              />
               <ProjectSettingsTab
                 project={viewModel.project}
                 onSaved={viewModel.refreshData}
@@ -675,7 +213,6 @@ const ProjectDetails = memo(() => {
         </>
       )}
 
-      {/* Modals */}
       <EditProjectModal
         isOpen={viewModel.isEditProjectModalOpen}
         onClose={viewModel.closeEditProjectModal}
@@ -696,30 +233,5 @@ const ProjectDetails = memo(() => {
 })
 
 ProjectDetails.displayName = "ProjectDetails"
-
-const EmptyState = ({
-  icon,
-  title,
-  description,
-  action,
-}: {
-  icon: React.ReactNode
-  title: string
-  description: string
-  action?: React.ReactNode
-}) => (
-  <Card>
-    <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
-      {icon}
-      <div className="space-y-1">
-        <h3 className="font-semibold text-foreground">{title}</h3>
-        <p className="mx-auto max-w-sm text-sm text-muted-foreground">
-          {description}
-        </p>
-      </div>
-      {action}
-    </CardContent>
-  </Card>
-)
 
 export default ProjectDetails

--- a/apps/studio/src/features/projects/routes/project-list.tsx
+++ b/apps/studio/src/features/projects/routes/project-list.tsx
@@ -14,6 +14,10 @@ import {
   MoreVertical,
 } from "lucide-react"
 import { Button } from "@/shared/ui/button"
+import {
+  formatProjectDate,
+  formatProjectTime,
+} from "@/features/projects/model/format-date"
 import { Input } from "@/shared/ui/input"
 import {
   Card,
@@ -44,35 +48,6 @@ import { cn } from "@/shared/lib/utils"
 
 const ProjectList = memo(() => {
   const viewModel = useProjectListViewModel()
-
-  const formatDate = (date: Date | string | undefined) => {
-    if (!date) return "Unknown"
-    try {
-      const dateObj = typeof date === "string" ? new Date(date) : date
-      if (isNaN(dateObj.getTime())) return "Unknown"
-      return new Intl.DateTimeFormat("en-US", {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-      }).format(dateObj)
-    } catch {
-      return "Unknown"
-    }
-  }
-
-  const formatTime = (date: Date | string | undefined) => {
-    if (!date) return "Unknown"
-    try {
-      const dateObj = typeof date === "string" ? new Date(date) : date
-      if (isNaN(dateObj.getTime())) return "Unknown"
-      return new Intl.DateTimeFormat("en-US", {
-        hour: "2-digit",
-        minute: "2-digit",
-      }).format(dateObj)
-    } catch {
-      return "Unknown"
-    }
-  }
 
   return (
     <div className="container mx-auto px-4 py-8">
@@ -261,7 +236,7 @@ const ProjectList = memo(() => {
                     <CardTitle className="truncate">{project.name}</CardTitle>
                     <CardDescription className="flex items-center gap-2 mt-1">
                       <Calendar className="h-3 w-3" />
-                      <span>Created {formatDate(project.createdAt)}</span>
+                      <span>Created {formatProjectDate(project.createdAt)}</span>
                     </CardDescription>
                   </div>
                   <Badge variant="secondary">
@@ -278,7 +253,7 @@ const ProjectList = memo(() => {
                   </div>
                   <div className="flex items-center gap-2 text-sm text-muted-foreground">
                     <Clock className="h-4 w-4" />
-                    <span>Modified {formatTime(project.updatedAt)}</span>
+                    <span>Modified {formatProjectTime(project.updatedAt)}</span>
                   </div>
                 </div>
               </CardContent>


### PR DESCRIPTION
Follow-up to #278, same treatment applied to the projects feature — the two largest remaining files in the app.

## Why

Both route files did everything inline. The low point was project-detail's Upload tab: an IIFE inside JSX wrapping a **second nested IIFE** just to choose between the image and document importers.

```jsx
{(() => {
  const modality = viewModel.project?.modality ?? "image"
  ...
  const mediaCard = isImageModality ? (
    <div>…60 lines…</div>
  ) : (
    (() => {          // <- nested IIFE
      ...
      return (<div>…75 lines…</div>)
    })()
  )
  return (<div>{mediaCard}…</div>)
})()}
```

## Structure

| File | Before | After |
|---|---|---|
| `routes/project-detail.tsx` | 725 | **237** |
| `routes/project-create.tsx` | 670 | **204** |

22 new files, largest 161 lines:

```
components/detail/   project-detail-header · project-toolbar · project-stats-grid
                     labeling-progress-card · classes-tab · class-card
                     add-data-tab · image-import-panel · document-import-panel
                     model-tab · project-detail-status · tab-heading
components/create/   project-step · labeling-step · template-card
                     template-category-nav · import-guide-card · data-step
                     staged-panel
components/          selected-file-list        (shared by both routes)
model/               config-info · format-date · use-project-detail-derivations
```

Derived state moved out of the components: `deriveConfigInfo` (the label-config parse deciding validity + data kind), `useProjectDetailDerivations` (next-item resolution, per-class counts), and `formatProjectDate`/`formatProjectTime` — which had been **copy-pasted into three files**. `project-list.tsx` now imports the shared formatters instead of redefining both on every render.

## shadcn adoption

| Was | Now |
|---|---|
| hand-rolled pill switcher + `tab === 0 &&` conditionals | `Tabs` / `TabsList` / `TabsContent` |
| `Label` + `Input` + help-text triples | `Field` / `FieldLabel` / `FieldDescription` |
| local `EmptyState`, plus loading and error blocks | `Empty` |
| stat tiles and staged-file rows | `Item` |
| hand-built `<div>` class distribution bars | `Progress` |
| two loose cloud buttons | `ButtonGroup` |
| `title=` attributes on the sync buttons | `Tooltip` |

`SelectedFileList` deduplicates the removable file list both routes had their own copy of — each previously using a raw `<button>` for remove, now a `Button` with an accessible name.

## Behaviour preserved

- 200-row spreadsheet preview cap and its "showing the first 200 of N" note
- modality → icon/heading mapping. I reordered the branches into one lookup; the registry confirms `importMode: "spreadsheet"` belongs only to the `tabular` kind, so audio/video/spreadsheet can't overlap and the mapping is equivalent
- save gating (`name && template available && config ok && hasItems`)
- the video and roadmap-template early returns in the Data step
- Base UI's `Tabs.Panel` only mounts the active panel, matching the previous conditional rendering

## Verification

`tsc -p tsconfig.app.json` clean · eslint clean on every touched file · `vite build` succeeds · 92 tests pass.

Static verification only, as with #278 — no component tests cover these screens, so a manual pass over project create (all 3 steps) and detail (all 5 tabs) is worth doing before merge.

Two lint errors remain under `features/projects`, both `react-hooks/set-state-in-effect` in `project-detail-viewmodel.ts` and `project-list-viewmodel.ts`. I confirmed both are pre-existing on `main` (identical output with this branch's changes stashed) and left them alone.

Still blocked on the same pre-existing `uuid` dependency gap from #278 — `vite build` fails on `main` regardless of this PR. I verified this branch builds by temporarily stubbing that import locally (reverted, not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)