### PR TITLE
fix(build): resolve unresolvable imports and make typecheck actually run

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc --noEmit && vite build",
+    "build": "tsc -b && vite build",
     "tauri": "tauri",
     "tauri:build": "tauri build",
     "lint": "eslint .",
@@ -14,7 +14,7 @@
     "test:watch": "vitest",
     "publish": "yarn run build",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,scss,md}\" --ignore-path .gitignore --ignore-path .prettierignore",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc -b"
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",
@@ -68,7 +68,6 @@
     "@types/react": "^19.2.17",
     "@types/react-color": "^3.0.13",
     "@types/react-dom": "^19.2.3",
-    "@types/uuid": "^11.0.0",
     "@vitejs/plugin-react": "^6.0.2",
     "@vitest/coverage-v8": "^4.1.9",
     "esbuild": "^0.25.10",

--- a/apps/studio/src/app/layout/main-layout.tsx
+++ b/apps/studio/src/app/layout/main-layout.tsx
@@ -18,7 +18,6 @@ import {
   SheetTitle,
 } from "@/shared/ui/sheet"
 import { Button } from "@/shared/ui/button"
-import { visuallyHidden } from "@base-ui/utils/visuallyHidden"
 
 type NavigationItem = {
   name: string
@@ -64,7 +63,7 @@ const MainLayout = () => {
           side="left"
           className="p-0 w-64 bg-background left-0 top-0 h-full fixed md:hidden"
         >
-          <SheetTitle style={visuallyHidden}>Main navigation</SheetTitle>
+          <SheetTitle className="sr-only">Main navigation</SheetTitle>
           <div className="flex items-center gap-2 mb-6 p-6">
             <img src="/logo.png" alt="ProjectHub Logo" className="h-7 w-7" />
             <span className="text-xl font-bold">ProjectHub</span>

--- a/apps/studio/src/features/projects/model/project-create-viewmodel.ts
+++ b/apps/studio/src/features/projects/model/project-create-viewmodel.ts
@@ -1,5 +1,4 @@
 import { useState } from "react"
-import { v4 as uuidv4 } from "uuid"
 import { useNavigate } from "react-router-dom"
 import { services } from "@/shared/services"
 import type { Annotation } from "@/shared/types/core"
@@ -145,7 +144,7 @@ export const useProjectCreateViewModel = () => {
       await allowImageDirectory(folder)
       const scanned = await scanImageDirectory(folder)
       const nextImages: ImageFile[] = scanned.map((image) => ({
-        id: uuidv4(),
+        id: crypto.randomUUID(),
         name: image.name,
         path: image.path,
         imagePath: image.name,
@@ -185,7 +184,7 @@ export const useProjectCreateViewModel = () => {
       )
     }
     const nextDocuments: DocumentFile[] = paths.map((path) => ({
-      id: uuidv4(),
+      id: crypto.randomUUID(),
       name: fileBaseName(path),
       path,
     }))
@@ -209,7 +208,7 @@ export const useProjectCreateViewModel = () => {
         data[key] = row[columnIndex] ?? ""
       })
       return {
-        id: uuidv4(),
+        id: crypto.randomUUID(),
         name: `${fileName} · row ${index + 1}`,
         path: "",
         data,
@@ -299,7 +298,7 @@ export const useProjectCreateViewModel = () => {
       picked.map(async (path) => {
         const { width, height } = await probeImageSize(path)
         return {
-          id: uuidv4(),
+          id: crypto.randomUUID(),
           name: fileBaseName(path),
           path,
           imagePath: fileBaseName(path),
@@ -330,7 +329,7 @@ export const useProjectCreateViewModel = () => {
       const seen = new Set(current.map((doc) => doc.path))
       const next = paths
         .filter((path) => !seen.has(path))
-        .map((path) => ({ id: uuidv4(), name: fileBaseName(path), path }))
+        .map((path) => ({ id: crypto.randomUUID(), name: fileBaseName(path), path }))
       return [...current, ...next]
     })
     setName((current) => current.trim() || "Dataset")
@@ -351,7 +350,7 @@ export const useProjectCreateViewModel = () => {
     setError(null)
     try {
       const project = await services.getProjectService().create({
-        id: uuidv4(),
+        id: crypto.randomUUID(),
         name: name.trim(),
         description: description.trim(),
         type,
@@ -388,7 +387,7 @@ export const useProjectCreateViewModel = () => {
       await Promise.all(
         derivedClasses.map((cls) =>
           services.getLabelService().createLabel({
-            id: uuidv4(),
+            id: crypto.randomUUID(),
             name: cls.name,
             color: cls.color,
             projectId: project.id,
@@ -459,7 +458,7 @@ export const useProjectCreateViewModel = () => {
                 drafts.map((draft) =>
                   services
                     .getAnnotationService()
-                    .createAnnotation({ id: uuidv4(), ...draft } as Annotation)
+                    .createAnnotation({ id: crypto.randomUUID(), ...draft } as Annotation)
                 )
               )
             } catch (sidecarError) {

--- a/apps/studio/src/features/projects/model/project-detail-viewmodel.ts
+++ b/apps/studio/src/features/projects/model/project-detail-viewmodel.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { Annotation, Item, Label, Project } from "@/shared/types/core"
 import { z } from "zod"
-import { v4 as uuidv4 } from "uuid"
 import { useNavigate } from "react-router-dom"
 import { listenToStudioEvents } from "@/shared/ipc/events"
 import { studioCommands } from "@/shared/ipc/studio"
@@ -191,7 +190,7 @@ export const useProjectDetailViewModel = (projectId: string) => {
       await allowImageDirectory(folder)
       const scanned = await scanImageDirectory(folder)
       const preparedImages: UploadImage[] = scanned.map((image) => ({
-        id: uuidv4(),
+        id: crypto.randomUUID(),
         name: image.name,
         path: image.path,
         imagePath: image.name,
@@ -221,7 +220,7 @@ export const useProjectDetailViewModel = (projectId: string) => {
         const seen = new Set(current.map((doc) => doc.path))
         const added = paths
           .filter((path) => !seen.has(path))
-          .map((path) => ({ id: uuidv4(), name: fileBaseName(path), path }))
+          .map((path) => ({ id: crypto.randomUUID(), name: fileBaseName(path), path }))
         return [...current, ...added]
       })
     } finally {
@@ -374,7 +373,7 @@ export const useProjectDetailViewModel = (projectId: string) => {
               await Promise.all(
                 drafts.map((draft) =>
                   services.getAnnotationService().createAnnotation({
-                    id: uuidv4(),
+                    id: crypto.randomUUID(),
                     ...draft,
                   } as Annotation)
                 )
@@ -415,7 +414,7 @@ export const useProjectDetailViewModel = (projectId: string) => {
       setIsCreatingLabel(true)
       try {
         const createdLabel = await services.getLabelService().createLabel({
-          id: uuidv4(),
+          id: crypto.randomUUID(),
           ...labelData,
           projectId,
           project_id: projectId,

--- a/apps/studio/tsconfig.node.json
+++ b/apps/studio/tsconfig.node.json
@@ -11,7 +11,9 @@
     "allowImportingTsExtensions": false,
     "isolatedModules": true,
     "moduleDetection": "force",
-    "noEmit": false,
+    // Type-checking only: `tsc -b` must not emit a vite.config.js next to the
+    // .ts source, which Vite would then prefer over it.
+    "noEmit": true,
 
     /* Linting */
     "strict": true,
@@ -22,4 +24,5 @@
     "composite": true
   },
   "include": ["vite.config.ts"]
+
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3184,13 +3184,6 @@
   resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz#60be8d21baab8c305132eb9cb912ed497852aadc"
   integrity sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==
 
-"@types/uuid@^11.0.0":
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-11.0.0.tgz#f4fa34bbf2af941148ef1973c4361fc43617971c"
-  integrity sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==
-  dependencies:
-    uuid "*"
-
 "@types/validate-npm-package-name@^4.0.2":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz#df0f7dac25df7761f7476605ddac54cb1abda26e"
@@ -8922,7 +8915,7 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-uuid@*, "uuid@^11.1.0 || ^12 || ^13 || ^14.0.0", uuid@^14.0.0:
+"uuid@^11.1.0 || ^12 || ^13 || ^14.0.0", uuid@^14.0.0:
   version "14.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.1.tgz#8a5975b3e038902bfd169a10b5202f5ec0cf3faf"
   integrity sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==


### PR DESCRIPTION
`vite build` fails on `main`. Two imports resolve to nothing, and the type-check that should have caught them was silently doing nothing at all.

## 1. `tsc --noEmit` was checking zero files

This is the reason the other two bugs reached `main`.

The root `tsconfig.json` is a solution file — `"files": []` plus project references. Plain `tsc` therefore has nothing to compile:

```
tsc --noEmit --listFiles              ->   0 files
tsc -p tsconfig.app.json --listFiles  -> 393 files
```

Both `build` (`tsc --noEmit && vite build`) and `typecheck` were running the empty form. Now they run `tsc -b`, which honours the references and also covers the vite-config project. I confirmed it genuinely fails by injecting `const probe: number = "not a number"` — `tsc -b` reported it, the old command did not.

**Side effect I had to fix:** `tsconfig.node.json` had `"noEmit": false`, so `tsc -b` started emitting a `vite.config.js` beside `vite.config.ts`. It wasn't gitignored, and Vite would prefer the `.js`. Set to `noEmit: true`, matching `tsconfig.app.json`. Verified a clean `tsc -b` now emits nothing.

## 2. `uuid` was never a declared dependency

Imported by the project create/detail viewmodels, but **no** package.json declares it. The root only pins it under `resolutions`, which installs nothing — root `dependencies` is `{}`.

It resolved by accident. `@types/uuid` declares:

```json
"dependencies": { "uuid": "*" }
```

A types package depending on the runtime package — yarn's flat hoisting made that copy reachable from `apps/studio`. Under any non-hoisted install (pnpm, yarn PnP) it vanishes and the build dies. That's exactly what happens in this working copy, where `apps/studio` carries a pnpm-installed `node_modules`.

Replaced with `crypto.randomUUID()`, already the established pattern in 8 other files including the annotation tool handlers, so nothing new is being introduced. `@types/uuid` is then unused, so it's dropped from `package.json` and `yarn.lock`.

## 3. `@base-ui/utils/visuallyHidden` does not exist

Only `@base-ui/react` is installed; there is no `@base-ui/utils` package at all. Swapped for `sr-only`.

## Verification

- `tsc -b` — clean, and emits no stray files
- `vite build` — succeeds
- `vitest run` — 92 passed
- `yarn install --frozen-lockfile --ignore-engines` — **succeeds**, so the hand-edited lockfile matches `package.json`. This matters: `release.yml` runs exactly that command, and a desynced lockfile would have traded one broken build for another.

Worth noting the release pipeline is directly affected — `tauri.conf.json` sets `beforeBuildCommand: "yarn build"`, which is the script fixed here.

## Two things I did not change

**`apps/studio/pnpm-lock.yaml` (untracked)** — this repo is yarn workspaces (`packageManager: yarn@1.22.22`), but `apps/studio` has been installed with pnpm. That's what turns the latent `uuid` bug into a hard failure locally. The fixes here make the build correct under either manager, but the mixed setup is worth resolving separately. I left the file alone since it's untracked and not mine to delete.

**48 eslint errors** across the app (22 `react-hooks/set-state-in-effect`, 14 `react-hooks/refs`, 8 `no-explicit-any`, and a few others). These are pre-existing, not part of the build, and not run by CI. Fixing the hooks ones means restructuring data loading in every viewmodel — a real behavioural change that deserves its own PR rather than being smuggled into a build fix.

## Note on authorship

Two of these fixes were already sitting uncommitted in the working tree when I started — `main-layout.tsx` (the `sr-only` swap) and the `crypto.randomUUID()` change in `project-detail-viewmodel.ts`. They were correct, so I've included them here rather than duplicating the work; the new parts are the `project-create-viewmodel.ts` occurrences, the dependency removal, the lockfile update, and the tsconfig/script fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)